### PR TITLE
Upgrade Jackson to 2.9.8 for security patches

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
     </parent>
 
     <artifactId>libhoney-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.honeycomb.libhoney</groupId>
     <artifactId>libhoney-java-parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>pom</packaging>    
     <name>libhoney-java (Parent)</name>
     <description>The Java client for sending events to Honeycomb (parent module)</description>
@@ -64,7 +64,7 @@
 
         <!-- COMPILE dependency versions -->
         <apacheClientVersion>4.1.3</apacheClientVersion>
-        <jacksonVersion>2.9.5</jacksonVersion>
+        <jacksonVersion>2.9.8</jacksonVersion>
         <slf4jVersion>1.7.25</slf4jVersion>
 
         <!-- TEST dependency versions -->


### PR DESCRIPTION
This addresses the following open CVEs:

| CVE | Description |
| --- | --- |
| CVE-2018-14718 | FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the slf4j-ext class from polymorphic deserialization. |
| CVE-2018-14719 | FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the blaze-ds-opt and blaze-ds-core classes from polymorphic deserialization. |
| CVE-2018-14720 | FasterXML jackson-databind 2.x before 2.9.7 might allow attackers to conduct external XML entity (XXE) attacks by leveraging failure to block unspecified JDK classes from polymorphic deserialization. |
| CVE-2018-14721 | FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to conduct server-side request forgery (SSRF) attacks by leveraging failure to block the axis2-jaxws class from polymorphic deserialization. |
| CVE-2018-19360 | FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the axis2-transport-jms class from polymorphic deserialization.| 
| CVE-2018-19361 | FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the openjpa class from polymorphic deserialization. |
| CVE-2018-19362 | FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the jboss-common-core class from polymorphic deserialization. |
| CVE-2018-1000873 | Fasterxml Jackson version Before 2.9.8 contains a CWE-20: Improper Input Validation vulnerability in Jackson-Modules-Java8 that can result in Causes a denial-of-service (DoS). This attack appear to be exploitable via The victim deserializes malicious input, specifically very large values in the nanoseconds field of a time value.  This vulnerability appears to have been fixed in 2.9.8. |