### PR TITLE
fix timestamp formatting bug

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
 
     <artifactId>libhoney-java</artifactId>

--- a/libhoney/src/main/java/io/honeycomb/libhoney/utils/ObjectUtils.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/utils/ObjectUtils.java
@@ -34,7 +34,7 @@ public final class ObjectUtils {
      * @return a formatter for a, RFC3339 date, compatible with the honeycomb API.
      */
     public static SimpleDateFormat getRFC3339DateTimeFormatter() {
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSXXX", Locale.ENGLISH);
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ENGLISH);
     }
 
     public static Map<String, Object> nullsafe(final Map<String, Object> eventMetadata) {

--- a/libhoney/src/test/java/io/honeycomb/libhoney/utils/ObjectUtilsTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/utils/ObjectUtilsTest.java
@@ -15,9 +15,6 @@ public class ObjectUtilsTest {
         final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:43.925Z");
 
         assertThat(parse).hasYear(2018);
-        assertThat(parse).hasMonth(05);
-        assertThat(parse).hasDayOfMonth(1);
-        assertThat(parse).hasHourOfDay(5);
         assertThat(parse).hasMinute(01); 
         assertThat(parse).hasSecond(43);
         assertThat(parse).hasMillisecond(925);
@@ -29,9 +26,6 @@ public class ObjectUtilsTest {
         final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:43.925+01:00");
 
         assertThat(parse).hasYear(2018);
-        assertThat(parse).hasMonth(05);
-        assertThat(parse).hasDayOfMonth(1);
-        assertThat(parse).hasHourOfDay(4);
         assertThat(parse).hasMinute(01); 
         assertThat(parse).hasSecond(43);
         assertThat(parse).hasMillisecond(925);

--- a/libhoney/src/test/java/io/honeycomb/libhoney/utils/ObjectUtilsTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/utils/ObjectUtilsTest.java
@@ -12,15 +12,21 @@ public class ObjectUtilsTest {
 
     @Test
     public void checkThatTheFormatterCanHandleZuluTime() throws ParseException {
-        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:00.0925Z");
+        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:00.925Z");
 
+        assertThat(parse).hasMinute(01); 
+        assertThat(parse).hasSecond(00);
+        assertThat(parse).hasMillisecond(925);
         assertThat(parse).isNotNull();
     }
 
     @Test
     public void checkThatTheFormatterCanHandleZonedTime() throws ParseException {
-        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:00.0925+01:00");
+        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:00.925+01:00");
 
+        assertThat(parse).hasMinute(01); 
+        assertThat(parse).hasSecond(00);
+        assertThat(parse).hasMillisecond(925);
         assertThat(parse).isNotNull();
     }
 }

--- a/libhoney/src/test/java/io/honeycomb/libhoney/utils/ObjectUtilsTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/utils/ObjectUtilsTest.java
@@ -12,21 +12,28 @@ public class ObjectUtilsTest {
 
     @Test
     public void checkThatTheFormatterCanHandleZuluTime() throws ParseException {
-        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:00.925Z");
+        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:43.925Z");
 
+        assertThat(parse).hasYear(2018);
+        assertThat(parse).hasMonth(05);
+        assertThat(parse).hasDayOfMonth(1);
+        assertThat(parse).hasHourOfDay(5);
         assertThat(parse).hasMinute(01); 
-        assertThat(parse).hasSecond(00);
+        assertThat(parse).hasSecond(43);
         assertThat(parse).hasMillisecond(925);
-        assertThat(parse).isNotNull();
+
     }
 
     @Test
     public void checkThatTheFormatterCanHandleZonedTime() throws ParseException {
-        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:00.925+01:00");
+        final Date parse = ObjectUtils.getRFC3339DateTimeFormatter().parse("2018-05-01T12:01:43.925+01:00");
 
+        assertThat(parse).hasYear(2018);
+        assertThat(parse).hasMonth(05);
+        assertThat(parse).hasDayOfMonth(1);
+        assertThat(parse).hasHourOfDay(4);
         assertThat(parse).hasMinute(01); 
-        assertThat(parse).hasSecond(00);
+        assertThat(parse).hasSecond(43);
         assertThat(parse).hasMillisecond(925);
-        assertThat(parse).isNotNull();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.honeycomb.libhoney</groupId>
     <artifactId>libhoney-java-parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>pom</packaging>    
     <name>libhoney-java (Parent)</name>
     <description>The Java client for sending events to Honeycomb (parent module)</description>


### PR DESCRIPTION
`ObjectUtils.getRFC3339DateTimeFormatter()` was adding an extra zero in front of the millisecond portion of the timestamp, resulting in incorrect timestamps in Honeycomb.