### PR TITLE
suppress 401 error log if an observer is attached

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
 
     <artifactId>libhoney-java</artifactId>

--- a/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
@@ -278,11 +278,12 @@ public class HoneycombBatchConsumer implements BatchConsumer<ResolvedEvent> {
 
         private void consumeSuccessful(final HttpResponse httpResponse) {
             markEndOfHttpRequest();
-            if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_UNAUTHORIZED) {
+            if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_UNAUTHORIZED && !observable.hasObservers()) {
                 // We log an error on any 401 because this is likely a critical configuration error and so should
                 // not require ResponseObserver, but should be clear from the logs.
                 // The alternative is to eagerly check the validity of the global write key on start-up (as in the
                 // existing GO SDK), but that relies on undocumented API features.
+                // Only log the error if there are no observers attached to handle it
                 LOG.error("Server responded with a 401 HTTP error code to a batch request. This is likely caused by " +
                     "using an incorrect 'Team Write Key'. Check https://ui.honeycomb.io/account to verify your " +
                     "team write key. An error has been published to the ResponseObservers for each event " +

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.honeycomb.libhoney</groupId>
     <artifactId>libhoney-java-parent</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <packaging>pom</packaging>    
     <name>libhoney-java (Parent)</name>
     <description>The Java client for sending events to Honeycomb (parent module)</description>


### PR DESCRIPTION
Users were being bombarded by error logs when encountering 401s, both in libhoney and in the ResponseObservers. This change should prevent libhoney from logging this error if an observer is attached. 
