### PR TITLE
Upgrade Jackson to 2.9.9.2 for more security patches

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -161,12 +161,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jacksonVersion}</version>
+            <version>${jacksonCoreVersion}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jacksonVersion}</version>
+            <version>${jacksonDatabindVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,8 @@
 
         <!-- COMPILE dependency versions -->
         <apacheClientVersion>4.1.3</apacheClientVersion>
-        <jacksonVersion>2.9.8</jacksonVersion>
+        <jacksonCoreVersion>2.9.9</jacksonCoreVersion>
+        <jacksonDatabindVersion>2.9.9.2</jacksonDatabindVersion>
         <slf4jVersion>1.7.25</slf4jVersion>
 
         <!-- TEST dependency versions -->


### PR DESCRIPTION
This addresses the following CVEs:

| title | description |
|-----|------------|
| CVE-2019-14439 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9.2. This occurs when Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the logback jar in the classpath. |
CVE-2019-14379 | SubTypeValidator.java in FasterXML jackson-databind before 2.9.9.2 mishandles default typing when ehcache is used, leading to remote code execution.
CVE-2019-12814 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has JDOM 1.x or 2.x jar in the classpath, an attacker can send a specifically crafted JSON message that allows them to read arbitrary local files on the server.
CVE-2019-12384 | FasterXML jackson-databind 2.x before 2.9.9.1 might allow attackers to have a variety of impacts by leveraging failure to block the logback-core class from polymorphic deserialization. Depending on the classpath content, remote code execution may be possible.
CVE-2019-12086 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.