### PR TITLE
Add support for HTTP authentication and SSLContext for HTTPClient

### DIFF
--- a/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
@@ -9,6 +9,7 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
 
 import java.net.URI;
+import javax.net.ssl.SSLContext;
 
 import static io.honeycomb.libhoney.utils.ObjectUtils.getOrDefault;
 
@@ -55,6 +56,7 @@ public class TransportOptions {
     private final long maximumHttpRequestShutdownWait;
     private final String additionalUserAgent;
     private final HttpHost proxy;
+    private final SSLContext sslContext;
 
     // parameter list is fine, since it's only used by the builder
     @SuppressWarnings("PMD.ExcessiveParameterList")
@@ -71,7 +73,8 @@ public class TransportOptions {
                      final Integer ioThreadCount,
                      final Long maximumHttpRequestShutdownWait,
                      final String additionalUserAgent,
-                     final HttpHost proxy) {
+                     final HttpHost proxy,
+                     final SSLContext sslContext) {
 
         //Batching-specific
         this.batchSize = getOrDefault(batchSize, DEFAULT_BATCH_SIZE);
@@ -91,6 +94,7 @@ public class TransportOptions {
             DEFAULT_MAX_HTTP_REQUEST_SHUTDOWN_WAIT);
         this.additionalUserAgent = getOrDefault(additionalUserAgent, DEFAULT_ADDITIONAL_USER_AGENT);
         this.proxy = proxy;
+        this.sslContext = sslContext;
 
         Assert.isTrue(this.batchSize >= 1, "batchSize must be 1 or greater");
         Assert.isTrue(this.batchTimeoutMillis >= 1, "batchTimeoutMillis must be 1 or greater");
@@ -212,6 +216,10 @@ public class TransportOptions {
         return proxy;
     }
 
+    public SSLContext getSSLContext() {
+        return sslContext;
+    }
+
     static TransportOptions.Builder builder() {
         return new TransportOptions.Builder();
     }
@@ -256,6 +264,7 @@ public class TransportOptions {
         private Long maximumHttpRequestShutdownWait;
         private String additionalUserAgent;
         private HttpHost proxy;
+        private SSLContext sslContext;
 
         /**
          * This creates a {@link TransportOptions} instance.
@@ -278,7 +287,8 @@ public class TransportOptions {
                 ioThreadCount,
                 maximumHttpRequestShutdownWait,
                 additionalUserAgent,
-                proxy);
+                proxy,
+                sslContext);
         }
 
         /**
@@ -625,6 +635,15 @@ public class TransportOptions {
 
         public TransportOptions.Builder setProxy(final HttpHost proxy) {
             this.proxy = proxy;
+            return this;
+        }
+
+        public SSLContext getSSLContext() {
+            return sslContext;
+        }
+
+        public TransportOptions.Builder setSSLContext(final SSLContext sslContext) {
+            this.sslContext = sslContext;
             return this;
         }
     }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
@@ -76,7 +76,7 @@ public class TransportOptions {
                      final Long maximumHttpRequestShutdownWait,
                      final String additionalUserAgent,
                      final HttpHost proxy,
-                     final SSLContext sslContext) {
+                     final SSLContext sslContext,
                      final CredentialsProvider credentialsProvider) {
 
         //Batching-specific
@@ -297,7 +297,7 @@ public class TransportOptions {
                 maximumHttpRequestShutdownWait,
                 additionalUserAgent,
                 proxy,
-                sslContext);
+                sslContext,
                 credentialsProvider);
         }
 

--- a/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
@@ -654,6 +654,7 @@ public class TransportOptions {
 
         public TransportOptions.Builder setSSLContext(final SSLContext sslContext) {
             this.sslContext = sslContext;
+            return this;
         }
 
         public CredentialsProvider getCredentialsProvider() {

--- a/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
@@ -7,6 +7,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.client.CredentialsProvider;
 
 import java.net.URI;
 
@@ -55,6 +56,7 @@ public class TransportOptions {
     private final long maximumHttpRequestShutdownWait;
     private final String additionalUserAgent;
     private final HttpHost proxy;
+    private final CredentialsProvider credentialsProvider;
 
     // parameter list is fine, since it's only used by the builder
     @SuppressWarnings("PMD.ExcessiveParameterList")
@@ -71,7 +73,8 @@ public class TransportOptions {
                      final Integer ioThreadCount,
                      final Long maximumHttpRequestShutdownWait,
                      final String additionalUserAgent,
-                     final HttpHost proxy) {
+                     final HttpHost proxy,
+                     final CredentialsProvider credentialsProvider) {
 
         //Batching-specific
         this.batchSize = getOrDefault(batchSize, DEFAULT_BATCH_SIZE);
@@ -91,6 +94,7 @@ public class TransportOptions {
             DEFAULT_MAX_HTTP_REQUEST_SHUTDOWN_WAIT);
         this.additionalUserAgent = getOrDefault(additionalUserAgent, DEFAULT_ADDITIONAL_USER_AGENT);
         this.proxy = proxy;
+        this.credentialsProvider = credentialsProvider;
 
         Assert.isTrue(this.batchSize >= 1, "batchSize must be 1 or greater");
         Assert.isTrue(this.batchTimeoutMillis >= 1, "batchTimeoutMillis must be 1 or greater");
@@ -212,6 +216,10 @@ public class TransportOptions {
         return proxy;
     }
 
+    public CredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
+    }
+
     static TransportOptions.Builder builder() {
         return new TransportOptions.Builder();
     }
@@ -256,6 +264,7 @@ public class TransportOptions {
         private Long maximumHttpRequestShutdownWait;
         private String additionalUserAgent;
         private HttpHost proxy;
+        private CredentialsProvider credentialsProvider;
 
         /**
          * This creates a {@link TransportOptions} instance.
@@ -278,7 +287,8 @@ public class TransportOptions {
                 ioThreadCount,
                 maximumHttpRequestShutdownWait,
                 additionalUserAgent,
-                proxy);
+                proxy,
+                credentialsProvider);
         }
 
         /**
@@ -625,6 +635,15 @@ public class TransportOptions {
 
         public TransportOptions.Builder setProxy(final HttpHost proxy) {
             this.proxy = proxy;
+            return this;
+        }
+
+        public CredentialsProvider getCredentialsProvider() {
+            return credentialsProvider;
+        }
+
+        public TransportOptions.Builder setCredentialsProvider(final CredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
             return this;
         }
     }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/TransportOptions.java
@@ -221,7 +221,7 @@ public class TransportOptions {
     }
 
     public SSLContext getSSLContext() {
-            return sslContext;
+        return sslContext;
     }
 
     public CredentialsProvider getCredentialsProvider() {

--- a/libhoney/src/main/java/io/honeycomb/libhoney/transport/impl/BatchingHttpTransport.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/transport/impl/BatchingHttpTransport.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
+import javax.net.ssl.SSLContext;
 
 /**
  * The default {@link Transport} used by the SDK.
@@ -110,6 +111,7 @@ public class BatchingHttpTransport implements Transport {
             .setMaxConnTotal(options.getMaxConnections())
             .setMaxConnPerRoute(options.getMaxHttpConnectionsPerApiHost())
             .setConnectionManagerShared(false)
+            .setSSLContext(options.getSSLContext())
             .setDefaultRequestConfig(
                 RequestConfig.custom()
                     .setProxy(options.getProxy())

--- a/libhoney/src/main/java/io/honeycomb/libhoney/transport/impl/BatchingHttpTransport.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/transport/impl/BatchingHttpTransport.java
@@ -125,7 +125,9 @@ public class BatchingHttpTransport implements Transport {
                 ConnectionConfig.custom()
                     .setBufferSize(options.getBufferSize())
                     .build()
-            ).build();
+            )
+            .setDefaultCredentialsProvider(options.getCredentialsProvider())
+            .build();
     }
 
 }


### PR DESCRIPTION
This expands the suite of options available to configure libhoney's HTTP behavior and allows setting a `CredentialProvider` (enabling basic auth, etc.) as well as a `SSLContext` (for custom certificate / SSL activity).