### PR TITLE
Dynamic UserAgent String

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -62,6 +62,18 @@
                         <transformer
                             implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
                         </transformer>
+                        <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Implementation-Title>${project.name}</Implementation-Title>
+                                <Implementation-Version>${project.version}</Implementation-Version>
+                                <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
+                                <Implementation-Title>${project.name}</Implementation-Title>
+                                <Specification-Version>${project.version}</Specification-Version>
+                                <Specification-Vendor>${project.organization.name}</Specification-Vendor>
+                            </manifestEntries>
+                        </transformer>
+
                     </transformers>
                 </configuration>
                 <executions>

--- a/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
@@ -49,7 +49,12 @@ public class HoneycombBatchConsumer implements BatchConsumer<ResolvedEvent> {
 
     private static final String BATCH_ENDPOINT_FORMAT = "/1/batch/%s";
     private static final String WRITE_KEY_HEADER = "X-Honeycomb-Team";
-    private static final String USER_AGENT = "libhoneycomb-java/" + LibHoney.class.getPackage().getImplementationVersion();
+    /** The following variable defaults to "libhoneycomb-java/1.0.0 as the implementation version is injected by
+     * the Maven build process and will not be available when running from IDE. This ensure unit tests run even without
+     * creating an actual artifact.
+     */
+    private static final String USER_AGENT = "libhoneycomb-java/" +
+        (LibHoney.class.getPackage().getImplementationVersion()==null ? "1.0.0" : LibHoney.class.getPackage().getImplementationVersion());
 
     private final CloseableHttpAsyncClient internalClient;
     private final ResponseObservable observable;

--- a/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
@@ -1,5 +1,6 @@
 package io.honeycomb.libhoney.transport.batch.impl;
 
+import io.honeycomb.libhoney.LibHoney;
 import io.honeycomb.libhoney.eventdata.ResolvedEvent;
 import io.honeycomb.libhoney.responses.ResponseObservable;
 import io.honeycomb.libhoney.responses.impl.EventResponseFactory;
@@ -48,7 +49,7 @@ public class HoneycombBatchConsumer implements BatchConsumer<ResolvedEvent> {
 
     private static final String BATCH_ENDPOINT_FORMAT = "/1/batch/%s";
     private static final String WRITE_KEY_HEADER = "X-Honeycomb-Team";
-    private static final String USER_AGENT = "libhoneycomb-java/1.0.0";
+    private static final String USER_AGENT = "libhoneycomb-java/" + LibHoney.class.getPackage().getImplementationVersion();
 
     private final CloseableHttpAsyncClient internalClient;
     private final ResponseObservable observable;

--- a/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java
@@ -54,7 +54,7 @@ public class HoneycombBatchConsumer implements BatchConsumer<ResolvedEvent> {
      * creating an actual artifact.
      */
     private static final String USER_AGENT = "libhoneycomb-java/" +
-        (LibHoney.class.getPackage().getImplementationVersion()==null ? "1.0.0" : LibHoney.class.getPackage().getImplementationVersion());
+        (LibHoney.class.getPackage().getImplementationVersion()==null ? "0.0.0" : LibHoney.class.getPackage().getImplementationVersion());
 
     private final CloseableHttpAsyncClient internalClient;
     private final ResponseObservable observable;

--- a/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
@@ -82,7 +82,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", equalTo("libhoneycomb-java/1.0.0"))
+            .withHeader("User-Agent", containing("libhoneycomb-java/"))
             .withRequestBody(equalToJson("[" +
                 "  {" +
                 "    \"data\": {\"SimpleData\": \"SimpleValue\"}," +
@@ -108,7 +108,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", equalTo("libhoneycomb-java/1.0.0"))
+            .withHeader("User-Agent", containing("libhoneycomb-java/"))
             .withRequestBody(equalToJson("[" +
                 "  {" +
                 "    \"data\": {\"SimpleData\": \"SimpleValue\"}," +
@@ -167,7 +167,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", equalTo("libhoneycomb-java/1.0.0"))
+            .withHeader("User-Agent", containing("libhoneycomb-java/"))
             .withRequestBody(equalToJson("[" +
                 "  {" +
                 "    \"data\": {" +
@@ -291,7 +291,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", equalTo("libhoneycomb-java/1.0.0"))
+            .withHeader("User-Agent", containing("libhoneycomb-java/"))
         );
     }
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
@@ -82,7 +82,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", containing("libhoneycomb-java/"))
+            .withHeader("User-Agent", matching("libhoneycomb-java/\\d+\\.\\d+\\.\\d+"))
             .withRequestBody(equalToJson("[" +
                 "  {" +
                 "    \"data\": {\"SimpleData\": \"SimpleValue\"}," +
@@ -108,7 +108,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", containing("libhoneycomb-java/"))
+            .withHeader("User-Agent", matching("libhoneycomb-java/\\d+\\.\\d+\\.\\d+"))
             .withRequestBody(equalToJson("[" +
                 "  {" +
                 "    \"data\": {\"SimpleData\": \"SimpleValue\"}," +
@@ -167,7 +167,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", containing("libhoneycomb-java/"))
+            .withHeader("User-Agent", matching("libhoneycomb-java/\\d+\\.\\d+\\.\\d+"))
             .withRequestBody(equalToJson("[" +
                 "  {" +
                 "    \"data\": {" +
@@ -291,7 +291,7 @@ public class End2EndTest {
         verify(postRequestedFor(urlPathMatching("/1/batch/testDataSet"))
             .withHeader("Content-Type", containing("application/json"))
             .withHeader("X-Honeycomb-Team", equalTo("testWriteKey"))
-            .withHeader("User-Agent", containing("libhoneycomb-java/"))
+            .withHeader("User-Agent", matching("libhoneycomb-java/\\d+\\.\\d+\\.\\d+"))
         );
     }
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumerTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumerTest.java
@@ -122,7 +122,7 @@ public class HoneycombBatchConsumerTest {
         consumer.consume(events);
         final HttpUriRequest value = captureRequest();
 
-        assertThat(value.getFirstHeader("user-agent").getValue()).isEqualTo("libhoneycomb-java/1.0.0");
+        assertThat(value.getFirstHeader("user-agent").getValue()).contains("libhoneycomb-java/");
     }
 
     @Test
@@ -133,7 +133,7 @@ public class HoneycombBatchConsumerTest {
         consumer.consume(events);
         final HttpUriRequest value = captureRequest();
 
-        assertThat(value.getFirstHeader("user-agent").getValue()).isEqualTo("libhoneycomb-java/1.0.0");
+        assertThat(value.getFirstHeader("user-agent").getValue()).contains("libhoneycomb-java/");
     }
 
     @Test
@@ -144,7 +144,9 @@ public class HoneycombBatchConsumerTest {
         consumer.consume(events);
         final HttpUriRequest value = captureRequest();
 
-        assertThat(value.getFirstHeader("user-agent").getValue()).isEqualTo("libhoneycomb-java/1.0.0 beeline/1.0.0");
+        String userAgent = value.getFirstHeader("user-agent").getValue();
+        assertThat(userAgent).contains("libhoneycomb-java/");
+        assertThat(userAgent).contains("beeline/");
     }
 
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumerTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumerTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -145,8 +146,7 @@ public class HoneycombBatchConsumerTest {
         final HttpUriRequest value = captureRequest();
 
         String userAgent = value.getFirstHeader("user-agent").getValue();
-        assertThat(userAgent).contains("libhoneycomb-java/");
-        assertThat(userAgent).contains("beeline/");
+        assertThat(userAgent).matches(Pattern.compile("libhoneycomb-java/\\d+\\.\\d+\\.\\d+ beeline/\\d+\\.\\d+\\.\\d+"));
     }
 
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumerTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumerTest.java
@@ -123,7 +123,7 @@ public class HoneycombBatchConsumerTest {
         consumer.consume(events);
         final HttpUriRequest value = captureRequest();
 
-        assertThat(value.getFirstHeader("user-agent").getValue()).contains("libhoneycomb-java/");
+        assertThat(value.getFirstHeader("user-agent").getValue()).matches(Pattern.compile("libhoneycomb-java/\\d+\\.\\d+\\.\\d+"));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class HoneycombBatchConsumerTest {
         consumer.consume(events);
         final HttpUriRequest value = captureRequest();
 
-        assertThat(value.getFirstHeader("user-agent").getValue()).contains("libhoneycomb-java/");
+        assertThat(value.getFirstHeader("user-agent").getValue()).matches(Pattern.compile("libhoneycomb-java/\\d+\\.\\d+\\.\\d+"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.honeycomb.libhoney</groupId>
     <artifactId>libhoney-java-parent</artifactId>
     <version>1.1.0</version>
-    <packaging>pom</packaging>    
+    <packaging>pom</packaging>
     <name>libhoney-java (Parent)</name>
     <description>The Java client for sending events to Honeycomb (parent module)</description>
     <url>https://github.com/honeycombio/libhoney-java</url>
@@ -78,7 +78,7 @@
         <compilerPluginVersion>3.7.0</compilerPluginVersion>
         <reportsPluginVersion>2.9</reportsPluginVersion>
         <mavenSourcePluginVersion>3.0.1</mavenSourcePluginVersion>
-        <javadocPluginVersion>3.0.0</javadocPluginVersion>
+        <javadocPluginVersion>3.0.1</javadocPluginVersion>
         <xrefPluginVersion>2.5</xrefPluginVersion>
         <mavenWrapperPluginVersion>0.6.0</mavenWrapperPluginVersion>
         <pmdPluginVersion>3.9.0</pmdPluginVersion>


### PR DESCRIPTION
Injected version to manifest via Maven and modified user agent to use injected version rather than hardcoded value. I used "0.0.0" version to signify people running non-release versions (e.g. from IDE) for analytics purposes on Honeycomb's server side in case these versions are tracked. Tests are written to enforce the 3-part pattern of `#.#.#`for versions. This solves #17 