### PR TITLE
Simplified Builder for HoneyClient

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -101,14 +101,6 @@
                     <analysisCache>true</analysisCache>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>libhoney-java</artifactId>
@@ -99,6 +99,14 @@
                     </rulesets>
                     <!-- enable incremental analysis -->
                     <analysisCache>true</analysisCache>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/libhoney/src/main/java/io/honeycomb/libhoney/DefaultDebugResponseObserver.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/DefaultDebugResponseObserver.java
@@ -1,0 +1,45 @@
+package io.honeycomb.libhoney;
+
+import io.honeycomb.libhoney.responses.ClientRejected;
+import io.honeycomb.libhoney.responses.ServerAccepted;
+import io.honeycomb.libhoney.responses.ServerRejected;
+import io.honeycomb.libhoney.responses.Unknown;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultDebugResponseObserver implements ResponseObserver {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultDebugResponseObserver.class);
+
+    protected static final String ERROR_TEMPLATE_401 = "Server responded with a 401 HTTP error code to a batch request." +
+        " This is likely caused by using an incorrect 'Team Write Key'. Check https://ui.honeycomb.io/account to verify your " +
+        "team write key. Rejected event: {}";
+    private static final int STATUS_UNAUTHORIZED = 401;
+
+    @Override
+    public void onServerAccepted(final ServerAccepted serverAccepted) {
+        LOG.trace("Event successfully sent to Honeycomb: {}", serverAccepted);
+    }
+
+    @Override
+    public void onServerRejected(final ServerRejected serverRejected) {
+        if (serverRejected.getBatchData().getBatchStatusCode() == STATUS_UNAUTHORIZED) {
+            handle401(serverRejected);
+        } else {
+            LOG.debug("Event rejected by Honeycomb server: {}", serverRejected);
+        }
+    }
+
+    @Override
+    public void onClientRejected(final ClientRejected clientRejected) {
+        LOG.debug("Event rejected on the client side: {}", clientRejected);
+    }
+
+    @Override
+    public void onUnknown(final Unknown unknown) {
+        LOG.debug("Received an unknown error while trying to send Event to Honeycomb: {}", unknown);
+    }
+
+    protected void handle401(final ServerRejected serverRejected) {
+        LOG.debug(ERROR_TEMPLATE_401, serverRejected);
+    }
+}

--- a/libhoney/src/main/java/io/honeycomb/libhoney/DefaultDebugResponseObserver.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/DefaultDebugResponseObserver.java
@@ -7,12 +7,17 @@ import io.honeycomb.libhoney.responses.Unknown;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.UnknownHostException;
+
 public class DefaultDebugResponseObserver implements ResponseObserver {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultDebugResponseObserver.class);
 
     protected static final String ERROR_TEMPLATE_401 = "Server responded with a 401 HTTP error code to a batch request." +
         " This is likely caused by using an incorrect 'Team Write Key'. Check https://ui.honeycomb.io/account to verify your " +
         "team write key. Rejected event: {}";
+    protected static final String ERROR_TEMPLATE_UNKNOWN_HOST_EXCEPTION = "Could not reach determine destination server. " +
+        "This could be due to 1) invalid apiHost 2) Could not resolve apiHost (firewall? dns?) 3) problem with proxy configuration. " +
+        "Unknown event: {}";
     private static final int STATUS_UNAUTHORIZED = 401;
 
     @Override
@@ -36,7 +41,11 @@ public class DefaultDebugResponseObserver implements ResponseObserver {
 
     @Override
     public void onUnknown(final Unknown unknown) {
-        LOG.debug("Received an unknown error while trying to send Event to Honeycomb: {}", unknown);
+        if(unknown.getException()!=null && UnknownHostException.class.isAssignableFrom(unknown.getException().getClass())){
+            LOG.debug(ERROR_TEMPLATE_UNKNOWN_HOST_EXCEPTION, unknown);
+        } else {
+            LOG.debug("Received an unknown error while trying to send Event to Honeycomb: {}", unknown);
+        }
     }
 
     protected void handle401(final ServerRejected serverRejected) {

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -1,18 +1,25 @@
 package io.honeycomb.libhoney.builders;
 
 import io.honeycomb.libhoney.DefaultDebugResponseObserver;
+import io.honeycomb.libhoney.Event;
+import io.honeycomb.libhoney.EventFactory;
 import io.honeycomb.libhoney.EventPostProcessor;
 import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.LibHoney;
 import io.honeycomb.libhoney.Options;
 import io.honeycomb.libhoney.ResponseObserver;
 import io.honeycomb.libhoney.TransportOptions;
 import io.honeycomb.libhoney.ValueSupplier;
+import io.honeycomb.libhoney.transport.batch.impl.HoneycombBatchConsumer;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
 
 import javax.net.ssl.SSLContext;
 import java.net.URI;
@@ -28,12 +35,21 @@ public class HoneyClientBuilder {
     private final Map<String, Credentials> credentialMap = new HashMap<>();
     protected TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
     protected Options.Builder optionsBuilder = new Options.Builder();
-    private List<ResponseObserver> responseObservers = new ArrayList<>();
     private boolean debugEnabled = false;
+    private final List<ResponseObserver> responseObservers = new ArrayList<>();
 
     /**
-     * Build new HoneyClient instance
-     * @return the new HoneyClient instance
+     * Build new HoneyClient instance as configured by calling the various builder methods previous to this call.
+     * <p/>
+     * <h3>Example</h3>
+     * <pre>{@code
+     * HoneyClient client = new HoneyClientBuilder()
+     *                          .dataSet("dataset")
+     *                          .writeKey("write key")
+     *                          .addProxyNoCredential("proxy.domain.com")
+     *                          .build()}</pre>
+     *
+     * @return new HoneyClient instance
      */
     public HoneyClient build() {
         configureOptionBuilder();
@@ -44,9 +60,9 @@ public class HoneyClientBuilder {
 
     }
 
-    private void configureClient(HoneyClient client) {
+    private void configureClient(final HoneyClient client) {
         if (!responseObservers.isEmpty()) {
-            for (ResponseObserver responseObserver : responseObservers) {
+            for (final ResponseObserver responseObserver : responseObservers) {
                 client.addResponseObserver(responseObserver);
             }
         }
@@ -62,10 +78,10 @@ public class HoneyClientBuilder {
     }
 
     private CredentialsProvider createCredentialsProvider() {
-        final BasicCredentialsProvider provider = new BasicCredentialsProvider();
-        for (Map.Entry<String, Credentials> entry : credentialMap.entrySet()) {
-            String proxy = entry.getKey();
-            Credentials credential = entry.getValue();
+        final CredentialsProvider provider = new BasicCredentialsProvider();
+        for (final Map.Entry<String, Credentials> entry : credentialMap.entrySet()) {
+            final String proxy = entry.getKey();
+            final Credentials credential = entry.getValue();
             final HttpHost proxyHost = HttpHost.create(proxy);
             final AuthScope authScope = new AuthScope(proxyHost);
             provider.setCredentials(authScope, credential);
@@ -82,129 +98,380 @@ public class HoneyClientBuilder {
         }
     }
 
-    public HoneyClientBuilder addGlobalField(String name, Object field) {
+    /**
+     * Use this to add fields to all events, where both keys and values are fixed.
+     * Entries may be overridden before the event is sent to the server. See "Usage" on {@link HoneyClient}'s
+     * class documentation.
+     * <p>
+     * Default: None
+     *
+     * @param name  the "key".
+     * @param field the "value"
+     * @return this.
+     * @see Options.Builder#setGlobalFields(java.util.Map)
+     */
+    public HoneyClientBuilder addGlobalField(final String name, final Object field) {
         this.globalFields.put(name, field);
         return this;
     }
 
-    public HoneyClientBuilder addGlobalDynamicFields(String name, ValueSupplier<?> valueSupplier) {
+    /**
+     * Use this method to supply fields to events, where keys are fixed but values are dynamically created at runtime.
+     * Entries may be overridden before the event is sent to the server. See "Usage" on {@link HoneyClient}'s
+     * class documentation.
+     * <p>
+     * Default: None
+     *
+     * @param name          the "key"
+     * @param valueSupplier calculates value
+     * @see Options.Builder#setGlobalDynamicFields(java.util.Map)
+     */
+    public HoneyClientBuilder addGlobalDynamicFields(final String name, final ValueSupplier<?> valueSupplier) {
         this.globalDynamicFields.put(name, valueSupplier);
         return this;
     }
 
-    public HoneyClientBuilder addProxyCredential(String proxyHost, String username, String password) {
+    /**
+     * Use this method to configure the HTTP client to use a proxy that needs authentication.
+     * <p/>
+     * For configuring a proxy server without authentication see: {@link #addProxyNoCredential(String)}
+     *
+     * @param proxyHost hostname of the proxy, frequently FQDN of the server
+     * @param username  username for authentication with proxy server
+     * @param password  password for authentication with proxy server
+     */
+    public HoneyClientBuilder addProxyCredential(final String proxyHost, final String username, final String password) {
         final UsernamePasswordCredentials credential = new UsernamePasswordCredentials(username, password);
         credentialMap.put(proxyHost, credential);
         return this;
     }
 
-    public HoneyClientBuilder sampleRate(int sampleRate) {
+    /**
+     * SampleRate is the rate at which to sample this event. Default is 1, meaning no sampling.
+     * The probability of sending is {@code 1/sampleRate}. In other words, if one out of every 250 events is to be
+     * sent when Send() is called, you would specify set sample rate to 250.
+     * <p>
+     * Must be greater than 1<br>
+     * Default: 1
+     *
+     * @param sampleRate average number of events until sample is taken.
+     */
+    public HoneyClientBuilder sampleRate(final int sampleRate) {
         optionsBuilder.setSampleRate(sampleRate);
         return this;
     }
 
-    public HoneyClientBuilder eventPostProcessor(EventPostProcessor eventPostProcessor) {
+    /**
+     * Set this to apply post processing to any event about to be submitted to Honeycomb.
+     * See {@link EventPostProcessor} for details.
+     * <p>
+     * Default: None
+     *
+     * @param eventPostProcessor to set.
+     * @return this.
+     */
+    public HoneyClientBuilder eventPostProcessor(final EventPostProcessor eventPostProcessor) {
         optionsBuilder.setEventPostProcessor(eventPostProcessor);
         return this;
     }
 
-    public HoneyClientBuilder batchSize(int batchSize) {
+    /**
+     * This determines that maximum number of events that get sent to the Honeycomb server (via a batch request).
+     * In other words, this is a trigger that will cause a batch request to be created if a batch reaches this
+     * maximum size.
+     * <p>
+     * Also see {@link io.honeycomb.libhoney.TransportOptions.Builder#setBatchTimeoutMillis}, as that might cause batch request to be created
+     * earlier (triggering on time rather than space).
+     * <p>
+     * Note: Events are grouped into batches that have the same write key, dataset name and API host.
+     * See {@link Event#setWriteKey(String)}, {@link Event#setDataset(String)}, and {@link Event#setApiHost(URI)}.
+     *
+     * @param batchSize max number of events to send in single data transmission
+     */
+    public HoneyClientBuilder batchSize(final int batchSize) {
         transportOptionsBuilder.setBatchSize(batchSize);
         return this;
     }
 
-    public HoneyClientBuilder batchTimeoutMillis(long batchTimeoutMillis) {
+    /**
+     * If batches do no fill up to the batch size in time (as defined by {@link TransportOptions.Builder#setBatchSize(int)}), then
+     * this timeout will trigger a batch request to the Honeycomb server. Essentially, for batches that fill
+     * slowly, this ensures that there is a temporal upper bound to when events are sent via a batch request.
+     * The time is measured in milliseconds.
+     * <p>
+     * Note: Events are grouped into batches that have the same write key, dataset name and API host.
+     * See {@link Event#setWriteKey(String)}, {@link Event#setDataset(String)}, and {@link Event#setApiHost(URI)}.
+     * <p>
+     * Default: 100
+     *
+     * @param batchTimeoutMillis milliseconds to send non-empty but not-full batch.
+     */
+    public HoneyClientBuilder batchTimeoutMillis(final long batchTimeoutMillis) {
         transportOptionsBuilder.setBatchTimeoutMillis(batchTimeoutMillis);
         return this;
     }
 
-    public HoneyClientBuilder queueCapacity(int queueCapacity) {
+    /**
+     * This sets the capacity of the queue that events are submitted to before they get processed for batching
+     * and eventually sent to the honeycomb HTTP endpoint.
+     * <p>
+     * Under normal circumstances this queue should remain near empty, but in case of heavy load it acts as a
+     * bounded buffer against a build up of backpressure from the batching and http client implementation.
+     * <p>
+     * Default: 10000
+     *
+     * @param queueCapacity queue size.
+     * @see io.honeycomb.libhoney.responses.ClientRejected.RejectionReason#QUEUE_OVERFLOW
+     * @see io.honeycomb.libhoney.transport.batch.BatchConsumer#consume(java.util.List)
+     */
+    public HoneyClientBuilder queueCapacity(final int queueCapacity) {
         transportOptionsBuilder.setQueueCapacity(queueCapacity);
         return this;
     }
 
 
-    public HoneyClientBuilder maxPendingBatchRequests(int maxPendingBatchRequests) {
+    /**
+     * This determines the maximum number of batch requests that can be still pending completion at any one time.
+     * Set to -1 if there is no maximum, i.e. the number of batch requests pending completion is allowed to grow
+     * without bound.
+     * <p>
+     * Once a batch request has been triggered (see {@link TransportOptions.Builder#setBatchSize(int)} and
+     * {@link TransportOptions.Builder#setBatchTimeoutMillis(long)}), then the batch request is submitted
+     * to {@link io.honeycomb.libhoney.transport.batch.BatchConsumer#consume(java.util.List)}.
+     * <p>
+     * If the maximum pending requests is reached, then
+     * {@link io.honeycomb.libhoney.transport.batch.BatchConsumer#consume(java.util.List)} may block until the number of
+     * pending requests has dropped below the threshold.
+     * <p>
+     * This allows backpressure to be created if the {@link io.honeycomb.libhoney.transport.batch.BatchConsumer}
+     * implementation cannot keep up with the number of batch requests being submitted. The intended consequence of
+     * this is that the event queue may reach its capacity and overflow.
+     * <p>
+     * See {@link TransportOptions.Builder#setQueueCapacity(int)}.
+     * <p>
+     * This configuration differs from {@link TransportOptions.Builder#getMaxConnections()} in that a batch request may be pending
+     * completion, but it may be still be waiting for an HTTP connection. This is the case in the default
+     * {@link HoneycombBatchConsumer} where the
+     * {@link org.apache.http.nio.client.HttpAsyncClient} maintains an internal unbounded pending queue for
+     * requests that are waiting for a connection. This configuration effectively puts a bound on the total
+     * number of batch requests being serviced by the HTTP client, regardless of whether they have
+     * a connection or not.
+     * <p>
+     * Default: 250
+     *
+     * @param maxPendingBatchRequests max simultaneous requests.
+     * @see TransportOptions.Builder#setMaxConnections(int)
+     */
+    public HoneyClientBuilder maxPendingBatchRequests(final int maxPendingBatchRequests) {
         transportOptionsBuilder.setMaximumPendingBatchRequests(maxPendingBatchRequests);
         return this;
     }
 
-    public HoneyClientBuilder maxConnections(int maxConnections) {
+    /**
+     * Set this to define the maximum amount of connections the http client may hold in its connection pool.
+     * In effect this is the maximum level of concurrent HTTP requests that may be in progress at any given time.
+     * <p>
+     * Default: 200
+     *
+     * @param maxConnections maximum number of connections.
+     * @see HttpAsyncClientBuilder#setMaxConnTotal(int)
+     */
+    public HoneyClientBuilder maxConnections(final int maxConnections) {
         transportOptionsBuilder.setMaxConnections(maxConnections);
         return this;
     }
 
-    public HoneyClientBuilder maxConnectionsPerApiHost(int maxConnectionsPerApiHost) {
+    /**
+     * Set this to define the maximum amount of connections the http client may hold in its connection pool for a
+     * given hostname.
+     * In effect this limits how many concurrent requests may be sent to a single host.
+     * <p>
+     * Default: 100
+     *
+     * @param maxConnectionsPerApiHost pool size for per hostname
+     * @see HttpAsyncClientBuilder#setMaxConnPerRoute(int)
+     */
+    public HoneyClientBuilder maxConnectionsPerApiHost(final int maxConnectionsPerApiHost) {
         transportOptionsBuilder.setMaxConnectionsPerApiHost(maxConnectionsPerApiHost);
         return this;
     }
 
-    public HoneyClientBuilder connectTimeout(int connectTimeout) {
+    /**
+     * Set this to define the http client's connect timeout in milliseconds. Set to 0 for no timeout.
+     * <p>
+     * Default: 0
+     *
+     * @param connectTimeout to set.
+     * @see RequestConfig#getConnectTimeout()
+     */
+    public HoneyClientBuilder connectTimeout(final int connectTimeout) {
         transportOptionsBuilder.setConnectTimeout(connectTimeout);
         return this;
     }
 
-    public HoneyClientBuilder connectionRequestTimeout(int connectionRequestTimeout) {
+    /**
+     * Set this to define the http client's connection request timeout in milliseconds. This defines the maximum
+     * time that a batch request can wait for a connection from the connection manager after
+     * submission to the HTTP client. Set to 0 for no timeout.
+     * <p>
+     * Beware that setting this to a non-zero value might conflict with the backpressure effect of the
+     * {@link io.honeycomb.libhoney.transport.batch.BatchConsumer} implementation, and so might see an increase
+     * in failed batches. See {@link #maxPendingBatchRequests(int)} for more detail.
+     * <p>
+     * Default: 0
+     *
+     * @param connectionRequestTimeout to set.
+     * @see RequestConfig#getConnectionRequestTimeout()
+     */
+    public HoneyClientBuilder connectionRequestTimeout(final int connectionRequestTimeout) {
         transportOptionsBuilder.setConnectionRequestTimeout(connectionRequestTimeout);
         return this;
     }
 
-    public HoneyClientBuilder socketTimeout(int socketTimeout) {
+    /**
+     * Set this to define the http client's socket timeout in milliseconds. Set to 0 for no timeout.
+     * <p>
+     * Default: 3000
+     *
+     * @param socketTimeout to set.
+     * @see RequestConfig#getSocketTimeout()
+     */
+    public HoneyClientBuilder socketTimeout(final int socketTimeout) {
         transportOptionsBuilder.setSocketTimeout(socketTimeout);
         return this;
     }
 
-    public HoneyClientBuilder bufferSize(int bufferSize) {
+    /**
+     * Set this to define the http client's socket buffer size in bytes.
+     * <p>
+     * Default: 8192
+     *
+     * @param bufferSize to set.
+     * @see org.apache.http.config.ConnectionConfig.Builder#setBufferSize(int)
+     */
+    public HoneyClientBuilder bufferSize(final int bufferSize) {
         transportOptionsBuilder.setBufferSize(bufferSize);
         return this;
     }
 
-    public HoneyClientBuilder ioThreadCount(int ioThreadCount) {
+    /**
+     * Set this to define the http client's io thread count. This is usually set to the number of CPU cores.
+     * <p>
+     * Default: System CPU cores.
+     *
+     * @param ioThreadCount to set, must be between 1 and the system's number of CPU cores.
+     * @see <a href="https://hc.apache.org/httpcomponents-core-ga/tutorial/html/nio.html">Apache http client NIO</a>
+     * @see IOReactorConfig#getIoThreadCount()
+     */
+    public HoneyClientBuilder ioThreadCount(final int ioThreadCount) {
         transportOptionsBuilder.setIoThreadCount(ioThreadCount);
         return this;
     }
 
-    public HoneyClientBuilder maximumHttpRequestShutdownWait(long maximumHttpRequestShutdownWait) {
+    /**
+     * Defines the maximum time (in milliseconds) that we should wait for any pending HTTP requests to complete
+     * during the client shutdown process.
+     * <p>
+     * Any requests that are still pending at the end of this wait period will be terminated.
+     * <p>
+     * Default: 2000
+     *
+     * @param maximumHttpRequestShutdownWait milliseconds.
+     * @see TransportOptions.Builder#setMaximumHttpRequestShutdownWait(long)
+     */
+    public HoneyClientBuilder maximumHttpRequestShutdownWait(final long maximumHttpRequestShutdownWait) {
         transportOptionsBuilder.setMaximumHttpRequestShutdownWait(maximumHttpRequestShutdownWait);
         return this;
     }
 
-    public HoneyClientBuilder additionalUserAgent(String additionalUserAgent) {
+    /**
+     * Set this to add an additional component to the user agent header sent to Honeycomb when Events are submitted.
+     * This is usually only of interest for instrumentation libraries that wrap LibHoney.
+     * <p>
+     * Default: None
+     *
+     * @param additionalUserAgent added to the user agent on http request header.
+     * @see TransportOptions.Builder#setAdditionalUserAgent(java.lang.String)
+     */
+    public HoneyClientBuilder additionalUserAgent(final String additionalUserAgent) {
         transportOptionsBuilder.setAdditionalUserAgent(additionalUserAgent);
         return this;
     }
 
-    public HoneyClientBuilder proxyNoCredentials(String proxyHost) {
-        transportOptionsBuilder.setProxy(new HttpHost(proxyHost));
+    /**
+     * Use this method to configure the HTTP client to use a proxy without authentication.
+     * <p/>
+     * For configuring a proxy server with authentication see: {@link #addProxyCredential(String, String, String)}
+     *
+     * @param host hostname of the proxy, frequently FQDN of the server
+     */
+    public HoneyClientBuilder addProxyNoCredential(final String host) {
+        transportOptionsBuilder.setProxy(new HttpHost(host));
         return this;
     }
 
-    public HoneyClientBuilder sslContext(SSLContext sslContext) {
+    public HoneyClientBuilder sslContext(final SSLContext sslContext) {
         transportOptionsBuilder.setSSLContext(sslContext);
         return this;
     }
 
-    public HoneyClientBuilder dataSet(String dataSet) {
+    /**
+     * Dataset is the name of the Honeycomb dataset to which to send these events.
+     * If it is specified during {@link LibHoney} initialization, it will be used as the default dataset for all
+     * events. If absent, dataset must be explicitly set on an {@link EventFactory} or {@link Event}.
+     *
+     * @param dataSet to set.
+     * @see Options.Builder#setDataset(java.lang.String)
+     * <p>
+     * Default: None
+     */
+    public HoneyClientBuilder dataSet(final String dataSet) {
         optionsBuilder.setDataset(dataSet);
         return this;
     }
 
-    public HoneyClientBuilder apiHost(String apiHost) throws URISyntaxException {
+    /**
+     * APIHost is the hostname for the Honeycomb API server to which to send this event.
+     * <p>
+     * Default: {@code https://api.honeycomb.io/}
+     *
+     * @param apiHost to set.
+     * @see Options.Builder#setApiHost(java.net.URI)
+     */
+    public HoneyClientBuilder apiHost(final String apiHost) throws URISyntaxException {
         optionsBuilder.setApiHost(new URI(apiHost));
         return this;
     }
 
-    public HoneyClientBuilder writeKey(String writeKey) {
+    /**
+     * WriteKey is the Honeycomb authentication token.
+     * If it is specified during {@link LibHoney} initialization, it will be used as the default write key for all
+     * events.
+     * If absent, write key must be explicitly set on a builder or event.
+     * Find your team write key at https://ui.honeycomb.io/account
+     * <p>
+     * Default: None
+     *
+     * @param writeKey to set.
+     * @see Options.Builder#setWriteKey(java.lang.String)
+     */
+    public HoneyClientBuilder writeKey(final String writeKey) {
         optionsBuilder.setWriteKey(writeKey);
         return this;
     }
 
-    public HoneyClientBuilder debug(boolean flag) {
-        this.debugEnabled = flag;
+    /**
+     * Setting Debug to true will ensure the DefaultDebugResponseObserver to the HoneyClient's list of response observers.
+     * Default: false
+     *
+     * @param enabled true to enable debug response observer
+     */
+    public HoneyClientBuilder debug(final boolean enabled) {
+        this.debugEnabled = enabled;
         return this;
     }
 
-    public HoneyClientBuilder addResponseObserver(ResponseObserver responseObserver) {
+    public HoneyClientBuilder addResponseObserver(final ResponseObserver responseObserver) {
         responseObservers.add(responseObserver);
         return this;
     }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -33,10 +33,10 @@ public class HoneyClientBuilder {
     private final Map<String, Object> globalFields = new HashMap<>();
     private final Map<String, ValueSupplier<?>> globalDynamicFields = new HashMap<>();
     private final Map<String, Credentials> credentialMap = new HashMap<>();
+    private final List<ResponseObserver> responseObservers = new ArrayList<>();
     protected TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
     protected Options.Builder optionsBuilder = new Options.Builder();
     private boolean debugEnabled = false;
-    private final List<ResponseObserver> responseObservers = new ArrayList<>();
 
     /**
      * Build new HoneyClient instance as configured by calling the various builder methods previous to this call.
@@ -106,7 +106,7 @@ public class HoneyClientBuilder {
      *
      * @param name  the "key".
      * @param field the "value"
-     * @return this.
+     * @return HoneyClientBuilder instance
      * @see Options.Builder#setGlobalFields(java.util.Map)
      */
     public HoneyClientBuilder addGlobalField(final String name, final Object field) {
@@ -123,6 +123,7 @@ public class HoneyClientBuilder {
      *
      * @param name          the "key"
      * @param valueSupplier calculates value
+     * @return HoneyClientBuilder instance
      * @see Options.Builder#setGlobalDynamicFields(java.util.Map)
      */
     public HoneyClientBuilder addGlobalDynamicFields(final String name, final ValueSupplier<?> valueSupplier) {
@@ -138,6 +139,7 @@ public class HoneyClientBuilder {
      * @param proxyHost hostname of the proxy, frequently FQDN of the server
      * @param username  username for authentication with proxy server
      * @param password  password for authentication with proxy server
+     * @return HoneyClientBuilder instance
      */
     public HoneyClientBuilder addProxyCredential(final String proxyHost, final String username, final String password) {
         final UsernamePasswordCredentials credential = new UsernamePasswordCredentials(username, password);
@@ -154,6 +156,7 @@ public class HoneyClientBuilder {
      * Default: 1
      *
      * @param sampleRate average number of events until sample is taken.
+     * @return HoneyClientBuilder instance
      */
     public HoneyClientBuilder sampleRate(final int sampleRate) {
         optionsBuilder.setSampleRate(sampleRate);
@@ -186,6 +189,7 @@ public class HoneyClientBuilder {
      * See {@link Event#setWriteKey(String)}, {@link Event#setDataset(String)}, and {@link Event#setApiHost(URI)}.
      *
      * @param batchSize max number of events to send in single data transmission
+     * @return HoneyClientBuilder instance
      */
     public HoneyClientBuilder batchSize(final int batchSize) {
         transportOptionsBuilder.setBatchSize(batchSize);
@@ -204,6 +208,7 @@ public class HoneyClientBuilder {
      * Default: 100
      *
      * @param batchTimeoutMillis max milliseconds to send a non-empty but not-full batch.
+     * @return HoneyClientBuilder instance
      */
     public HoneyClientBuilder batchTimeoutMillis(final long batchTimeoutMillis) {
         transportOptionsBuilder.setBatchTimeoutMillis(batchTimeoutMillis);
@@ -220,6 +225,7 @@ public class HoneyClientBuilder {
      * Default: 10000
      *
      * @param queueCapacity queue size.
+     * @return HoneyClientBuilder instance
      * @see io.honeycomb.libhoney.responses.ClientRejected.RejectionReason#QUEUE_OVERFLOW
      * @see io.honeycomb.libhoney.transport.batch.BatchConsumer#consume(java.util.List)
      */
@@ -259,6 +265,7 @@ public class HoneyClientBuilder {
      * Default: 250
      *
      * @param maxPendingBatchRequests max simultaneous requests.
+     * @return HoneyClientBuilder instance
      * @see TransportOptions.Builder#setMaxConnections(int)
      */
     public HoneyClientBuilder maxPendingBatchRequests(final int maxPendingBatchRequests) {
@@ -273,6 +280,7 @@ public class HoneyClientBuilder {
      * Default: 200
      *
      * @param maxConnections maximum number of connections.
+     * @return HoneyClientBuilder instance
      * @see HttpAsyncClientBuilder#setMaxConnTotal(int)
      */
     public HoneyClientBuilder maxConnections(final int maxConnections) {
@@ -288,6 +296,7 @@ public class HoneyClientBuilder {
      * Default: 100
      *
      * @param maxConnectionsPerApiHost pool size for per hostname
+     * @return HoneyClientBuilder instance
      * @see HttpAsyncClientBuilder#setMaxConnPerRoute(int)
      */
     public HoneyClientBuilder maxConnectionsPerApiHost(final int maxConnectionsPerApiHost) {
@@ -301,6 +310,7 @@ public class HoneyClientBuilder {
      * Default: 0
      *
      * @param connectTimeout to set.
+     * @return HoneyClientBuilder instance
      * @see RequestConfig#getConnectTimeout()
      */
     public HoneyClientBuilder connectTimeout(final int connectTimeout) {
@@ -320,6 +330,7 @@ public class HoneyClientBuilder {
      * Default: 0
      *
      * @param connectionRequestTimeout to set.
+     * @return HoneyClientBuilder instance
      * @see RequestConfig#getConnectionRequestTimeout()
      */
     public HoneyClientBuilder connectionRequestTimeout(final int connectionRequestTimeout) {
@@ -333,6 +344,7 @@ public class HoneyClientBuilder {
      * Default: 3000
      *
      * @param socketTimeout to set.
+     * @return HoneyClientBuilder instance
      * @see RequestConfig#getSocketTimeout()
      */
     public HoneyClientBuilder socketTimeout(final int socketTimeout) {
@@ -346,6 +358,7 @@ public class HoneyClientBuilder {
      * Default: 8192
      *
      * @param bufferSize to set.
+     * @return HoneyClientBuilder instance
      * @see org.apache.http.config.ConnectionConfig.Builder#setBufferSize(int)
      */
     public HoneyClientBuilder bufferSize(final int bufferSize) {
@@ -359,6 +372,7 @@ public class HoneyClientBuilder {
      * Default: System CPU cores.
      *
      * @param ioThreadCount to set, must be between 1 and the system's number of CPU cores.
+     * @return HoneyClientBuilder instance
      * @see <a href="https://hc.apache.org/httpcomponents-core-ga/tutorial/html/nio.html">Apache http client NIO</a>
      * @see IOReactorConfig#getIoThreadCount()
      */
@@ -376,6 +390,7 @@ public class HoneyClientBuilder {
      * Default: 2000
      *
      * @param maximumHttpRequestShutdownWait milliseconds.
+     * @return HoneyClientBuilder instance
      * @see TransportOptions.Builder#setMaximumHttpRequestShutdownWait(long)
      */
     public HoneyClientBuilder maximumHttpRequestShutdownWait(final long maximumHttpRequestShutdownWait) {
@@ -390,6 +405,7 @@ public class HoneyClientBuilder {
      * Default: None
      *
      * @param additionalUserAgent added to the user agent on http request header.
+     * @return HoneyClientBuilder instance
      * @see TransportOptions.Builder#setAdditionalUserAgent(java.lang.String)
      */
     public HoneyClientBuilder additionalUserAgent(final String additionalUserAgent) {
@@ -403,6 +419,7 @@ public class HoneyClientBuilder {
      * For configuring a proxy server with authentication see: {@link #addProxyCredential(String, String, String)}
      *
      * @param host hostname of the proxy, frequently FQDN of the server
+     * @return HoneyClientBuilder instance
      */
     public HoneyClientBuilder addProxyNoCredential(final String host) {
         transportOptionsBuilder.setProxy(new HttpHost(host));
@@ -420,6 +437,7 @@ public class HoneyClientBuilder {
      * events. If absent, dataset must be explicitly set on an {@link EventFactory} or {@link Event}.
      *
      * @param dataSet to set.
+     * @return HoneyClientBuilder instance
      * @see Options.Builder#setDataset(java.lang.String)
      * <p>
      * Default: None
@@ -435,8 +453,9 @@ public class HoneyClientBuilder {
      * Default: {@code https://api.honeycomb.io/}
      *
      * @param apiHost to set.
+     * @return HoneyClientBuilder instance
+     * @throws URISyntaxException if host is not valid URI syntax
      * @see Options.Builder#setApiHost(java.net.URI)
-     * @throws URISyntaxException
      */
     public HoneyClientBuilder apiHost(final String apiHost) throws URISyntaxException {
         optionsBuilder.setApiHost(new URI(apiHost));
@@ -453,6 +472,7 @@ public class HoneyClientBuilder {
      * Default: None
      *
      * @param writeKey to set.
+     * @return HoneyClientBuilder instance
      * @see Options.Builder#setWriteKey(java.lang.String)
      */
     public HoneyClientBuilder writeKey(final String writeKey) {
@@ -465,6 +485,7 @@ public class HoneyClientBuilder {
      * Default: false
      *
      * @param enabled true to enable debug response observer
+     * @return HoneyClientBuilder instance
      */
     public HoneyClientBuilder debug(final boolean enabled) {
         this.debugEnabled = enabled;

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -37,16 +37,20 @@ public class HoneyClientBuilder {
     TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
     Options.Builder optionsBuilder = new Options.Builder();
 
-    public HoneyClient build() throws IllegalArgumentException, URISyntaxException {
+    /**
+     * Build new HoneyClient instance
+     * @return the new HoneyClient instance
+     */
+    public HoneyClient build() {
         configureOptionBuilder();
         configureTransportOptionBuilder();
         final HoneyClient client = new HoneyClient(optionsBuilder.build(), transportOptionsBuilder.build());
-        customizeClient(client);
+        configureClient(client);
         return client;
 
     }
 
-    private void customizeClient(HoneyClient client) {
+    private void configureClient(HoneyClient client) {
         if(!responseObservers.isEmpty()){
             for (ResponseObserver responseObserver : responseObservers) {
                 client.addResponseObserver(responseObserver);
@@ -57,14 +61,10 @@ public class HoneyClientBuilder {
         }
     }
 
-    private TransportOptions.Builder configureTransportOptionBuilder() {
-        final TransportOptions.Builder transportBuilder = new TransportOptions.Builder();
-
+    private void configureTransportOptionBuilder() {
         if(!credentialMap.isEmpty()){
-
-            transportBuilder.setCredentialsProvider(createCredentialsProvider());
+            transportOptionsBuilder.setCredentialsProvider(createCredentialsProvider());
         }
-        return transportBuilder;
     }
 
     private CredentialsProvider createCredentialsProvider() {
@@ -79,15 +79,13 @@ public class HoneyClientBuilder {
         return provider;
     }
 
-    private Options.Builder configureOptionBuilder() throws URISyntaxException {
+    private void configureOptionBuilder() {
         if(!globalFields.isEmpty()){
             optionsBuilder.setGlobalFields(globalFields);
         }
         if(!globalDynamicFields.isEmpty()){
             optionsBuilder.setGlobalDynamicFields(globalDynamicFields);
         }
-
-        return optionsBuilder;
     }
 
     public HoneyClientBuilder addGlobalField(String name, Object field) {

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -47,7 +47,7 @@ public class HoneyClientBuilder {
      * HoneyClient client = new HoneyClientBuilder()
      *                          .dataSet("dataset")
      *                          .writeKey("write key")
-     *                          .addProxyNoCredential("proxy.domain.com")
+     *                          .addProxy("proxy.domain.com")
      *                          .build()}</pre>
      *
      * @return new HoneyClient instance

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -143,14 +143,14 @@ public class HoneyClientBuilder {
     /**
      * Use this method to configure the HTTP client to use a proxy that needs authentication.
      * <p>
-     * For configuring a proxy server without authentication see: {@link #addProxyNoCredential(String)}
+     * For configuring a proxy server without authentication see: {@link #addProxy(String)}
      *
      * @param proxyHost hostname of the proxy, frequently FQDN of the server
      * @param username  username for authentication with proxy server
      * @param password  password for authentication with proxy server
      * @return HoneyClientBuilder instance
      */
-    public HoneyClientBuilder addProxyCredential(final String proxyHost, final String username, final String password) {
+    public HoneyClientBuilder addProxy(final String proxyHost, final String username, final String password) {
         final UsernamePasswordCredentials credential = new UsernamePasswordCredentials(username, password);
         credentialMap.put(proxyHost, credential);
         return this;
@@ -425,12 +425,12 @@ public class HoneyClientBuilder {
     /**
      * Use this method to configure the HTTP client to use a proxy without authentication.
      * <p>
-     * For configuring a proxy server with authentication see: {@link #addProxyCredential(String, String, String)}
+     * For configuring a proxy server with authentication see: {@link #addProxy(String, String, String)}
      *
      * @param host hostname of the proxy, frequently FQDN of the server
      * @return HoneyClientBuilder instance
      */
-    public HoneyClientBuilder addProxyNoCredential(final String host) {
+    public HoneyClientBuilder addProxy(final String host) {
         transportOptionsBuilder.setProxy(new HttpHost(host));
         return this;
     }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -1,0 +1,225 @@
+package io.honeycomb.libhoney.builders;
+
+import io.honeycomb.libhoney.DefaultDebugResponseObserver;
+import io.honeycomb.libhoney.EventPostProcessor;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.Options;
+import io.honeycomb.libhoney.ResponseObserver;
+import io.honeycomb.libhoney.TransportOptions;
+import io.honeycomb.libhoney.ValueSupplier;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+
+import javax.net.ssl.SSLContext;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HoneyClientBuilder {
+    private List<ResponseObserver> responseObservers = new ArrayList<>();
+    private boolean debugEnabled = false;
+
+    // HoneyClient Options START
+    private final Map<String, Object> globalFields = new HashMap<>();
+    private final Map<String, ValueSupplier<?>> globalDynamicFields = new HashMap<>();
+    // HoneyClient Options END
+
+    private final Map<String, Credentials> credentialMap = new HashMap<>();
+    // HoneyClient TransportOptions END
+
+    TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
+    Options.Builder optionsBuilder = new Options.Builder();
+
+    public HoneyClient build() throws IllegalArgumentException, URISyntaxException {
+        configureOptionBuilder();
+        configureTransportOptionBuilder();
+        final HoneyClient client = new HoneyClient(optionsBuilder.build(), transportOptionsBuilder.build());
+        customizeClient(client);
+        return client;
+
+    }
+
+    private void customizeClient(HoneyClient client) {
+        if(!responseObservers.isEmpty()){
+            for (ResponseObserver responseObserver : responseObservers) {
+                client.addResponseObserver(responseObserver);
+            }
+        }
+        if(debugEnabled){
+            client.addResponseObserver(new DefaultDebugResponseObserver());
+        }
+    }
+
+    private TransportOptions.Builder configureTransportOptionBuilder() {
+        final TransportOptions.Builder transportBuilder = new TransportOptions.Builder();
+
+        if(!credentialMap.isEmpty()){
+
+            transportBuilder.setCredentialsProvider(createCredentialsProvider());
+        }
+        return transportBuilder;
+    }
+
+    private CredentialsProvider createCredentialsProvider() {
+        final BasicCredentialsProvider provider = new BasicCredentialsProvider();
+        for (Map.Entry<String, Credentials> entry : credentialMap.entrySet()) {
+            String proxy = entry.getKey();
+            Credentials credential = entry.getValue();
+            final HttpHost proxyHost = HttpHost.create(proxy);
+            final AuthScope authScope = new AuthScope(proxyHost);
+            provider.setCredentials(authScope, credential);
+        }
+        return provider;
+    }
+
+    private Options.Builder configureOptionBuilder() throws URISyntaxException {
+        if(!globalFields.isEmpty()){
+            optionsBuilder.setGlobalFields(globalFields);
+        }
+        if(!globalDynamicFields.isEmpty()){
+            optionsBuilder.setGlobalDynamicFields(globalDynamicFields);
+        }
+
+        return optionsBuilder;
+    }
+
+    public HoneyClientBuilder addGlobalField(String name, Object field) {
+        this.globalFields.put(name, field);
+        return this;
+    }
+
+    public HoneyClientBuilder addGlobalDynamicFields(String name, ValueSupplier<?> valueSupplier) {
+        this.globalDynamicFields.put(name, valueSupplier);
+        return this;
+    }
+
+    public HoneyClientBuilder addProxyCredential(String proxyHost, String username, String password) {
+        final UsernamePasswordCredentials credential = new UsernamePasswordCredentials(username, password);
+        credentialMap.put(proxyHost, credential);
+        return this;
+    }
+
+    public HoneyClientBuilder setSampleRate(int sampleRate) {
+        optionsBuilder.setSampleRate(sampleRate);
+        return this;
+    }
+
+    public HoneyClientBuilder setEventPostProcessor(EventPostProcessor eventPostProcessor) {
+        optionsBuilder.setEventPostProcessor(eventPostProcessor);
+        return this;
+    }
+
+    public HoneyClientBuilder setBatchSize(int batchSize) {
+        transportOptionsBuilder.setBatchSize(batchSize);
+        return this;
+    }
+
+    public HoneyClientBuilder setBatchTimeoutMillis(long batchTimeoutMillis) {
+        transportOptionsBuilder.setBatchTimeoutMillis(batchTimeoutMillis);
+        return this;
+    }
+
+    public HoneyClientBuilder setQueueCapacity(int queueCapacity) {
+        transportOptionsBuilder.setQueueCapacity(queueCapacity);
+        return this;
+    }
+
+    public HoneyClientBuilder setMaximumPendingBatchRequests(int maximumPendingBatchRequests) {
+        transportOptionsBuilder.setMaximumPendingBatchRequests(maximumPendingBatchRequests);
+        return this;
+    }
+
+    public HoneyClientBuilder setMaxPendingBatchRequests(int maxPendingBatchRequests) {
+        transportOptionsBuilder.setMaximumPendingBatchRequests(maxPendingBatchRequests);
+        return this;
+    }
+
+    public HoneyClientBuilder setMaxConnections(int maxConnections) {
+        transportOptionsBuilder.setMaxConnections(maxConnections);
+        return this;
+    }
+
+    public HoneyClientBuilder setMaxConnectionsPerApiHost(int maxConnectionsPerApiHost) {
+        transportOptionsBuilder.setMaxConnectionsPerApiHost(maxConnectionsPerApiHost);
+        return this;
+    }
+
+    public HoneyClientBuilder setConnectTimeout(int connectTimeout) {
+        transportOptionsBuilder.setConnectTimeout(connectTimeout);
+        return this;
+    }
+
+    public HoneyClientBuilder setConnectionRequestTimeout(int connectionRequestTimeout) {
+        transportOptionsBuilder.setConnectionRequestTimeout(connectionRequestTimeout);
+        return this;
+    }
+
+    public HoneyClientBuilder setSocketTimeout(int socketTimeout) {
+        transportOptionsBuilder.setSocketTimeout(socketTimeout);
+        return this;
+    }
+
+    public HoneyClientBuilder setBufferSize(int bufferSize) {
+        transportOptionsBuilder.setBufferSize(bufferSize);
+        return this;
+    }
+
+    public HoneyClientBuilder setIoThreadCount(int ioThreadCount) {
+        transportOptionsBuilder.setIoThreadCount(ioThreadCount);
+        return this;
+    }
+
+    public HoneyClientBuilder setMaximumHttpRequestShutdownWait(long maximumHttpRequestShutdownWait) {
+        transportOptionsBuilder.setMaximumHttpRequestShutdownWait(maximumHttpRequestShutdownWait);
+        return this;
+    }
+
+    public HoneyClientBuilder setAdditionalUserAgent(String additionalUserAgent) {
+        transportOptionsBuilder.setAdditionalUserAgent(additionalUserAgent);
+        return this;
+    }
+
+    public HoneyClientBuilder setProxyNoCredentials(String proxyHost) {
+        transportOptionsBuilder.setProxy(new HttpHost(proxyHost));
+        return this;
+    }
+
+    public HoneyClientBuilder setSSLContext(SSLContext sslContext) {
+        transportOptionsBuilder.setSSLContext(sslContext);
+        return this;
+    }
+
+    public HoneyClientBuilder setDataSet(String dataSet) {
+        optionsBuilder.setDataset(dataSet);
+        return this;
+    }
+
+    public HoneyClientBuilder setApiHost(String apiHost) throws URISyntaxException {
+        optionsBuilder.setApiHost(new URI(apiHost));
+        return this;
+    }
+
+    public HoneyClientBuilder setWriteKey(String writeKey) {
+        optionsBuilder.setWriteKey(writeKey);
+        return this;
+    }
+
+    public HoneyClientBuilder setDebugFlag(boolean flag){
+        this.debugEnabled = flag;
+        return this;
+    }
+
+    public HoneyClientBuilder addResponseObserver(ResponseObserver responseObserver) {
+        responseObservers.add(responseObserver);
+        return this;
+    }
+
+
+}

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -104,112 +104,112 @@ public class HoneyClientBuilder {
         return this;
     }
 
-    public HoneyClientBuilder setSampleRate(int sampleRate) {
+    public HoneyClientBuilder sampleRate(int sampleRate) {
         optionsBuilder.setSampleRate(sampleRate);
         return this;
     }
 
-    public HoneyClientBuilder setEventPostProcessor(EventPostProcessor eventPostProcessor) {
+    public HoneyClientBuilder eventPostProcessor(EventPostProcessor eventPostProcessor) {
         optionsBuilder.setEventPostProcessor(eventPostProcessor);
         return this;
     }
 
-    public HoneyClientBuilder setBatchSize(int batchSize) {
+    public HoneyClientBuilder batchSize(int batchSize) {
         transportOptionsBuilder.setBatchSize(batchSize);
         return this;
     }
 
-    public HoneyClientBuilder setBatchTimeoutMillis(long batchTimeoutMillis) {
+    public HoneyClientBuilder batchTimeoutMillis(long batchTimeoutMillis) {
         transportOptionsBuilder.setBatchTimeoutMillis(batchTimeoutMillis);
         return this;
     }
 
-    public HoneyClientBuilder setQueueCapacity(int queueCapacity) {
+    public HoneyClientBuilder queueCapacity(int queueCapacity) {
         transportOptionsBuilder.setQueueCapacity(queueCapacity);
         return this;
     }
 
-    public HoneyClientBuilder setMaximumPendingBatchRequests(int maximumPendingBatchRequests) {
+    public HoneyClientBuilder maximumPendingBatchRequests(int maximumPendingBatchRequests) {
         transportOptionsBuilder.setMaximumPendingBatchRequests(maximumPendingBatchRequests);
         return this;
     }
 
-    public HoneyClientBuilder setMaxPendingBatchRequests(int maxPendingBatchRequests) {
+    public HoneyClientBuilder maxPendingBatchRequests(int maxPendingBatchRequests) {
         transportOptionsBuilder.setMaximumPendingBatchRequests(maxPendingBatchRequests);
         return this;
     }
 
-    public HoneyClientBuilder setMaxConnections(int maxConnections) {
+    public HoneyClientBuilder maxConnections(int maxConnections) {
         transportOptionsBuilder.setMaxConnections(maxConnections);
         return this;
     }
 
-    public HoneyClientBuilder setMaxConnectionsPerApiHost(int maxConnectionsPerApiHost) {
+    public HoneyClientBuilder maxConnectionsPerApiHost(int maxConnectionsPerApiHost) {
         transportOptionsBuilder.setMaxConnectionsPerApiHost(maxConnectionsPerApiHost);
         return this;
     }
 
-    public HoneyClientBuilder setConnectTimeout(int connectTimeout) {
+    public HoneyClientBuilder connectTimeout(int connectTimeout) {
         transportOptionsBuilder.setConnectTimeout(connectTimeout);
         return this;
     }
 
-    public HoneyClientBuilder setConnectionRequestTimeout(int connectionRequestTimeout) {
+    public HoneyClientBuilder connectionRequestTimeout(int connectionRequestTimeout) {
         transportOptionsBuilder.setConnectionRequestTimeout(connectionRequestTimeout);
         return this;
     }
 
-    public HoneyClientBuilder setSocketTimeout(int socketTimeout) {
+    public HoneyClientBuilder socketTimeout(int socketTimeout) {
         transportOptionsBuilder.setSocketTimeout(socketTimeout);
         return this;
     }
 
-    public HoneyClientBuilder setBufferSize(int bufferSize) {
+    public HoneyClientBuilder bufferSize(int bufferSize) {
         transportOptionsBuilder.setBufferSize(bufferSize);
         return this;
     }
 
-    public HoneyClientBuilder setIoThreadCount(int ioThreadCount) {
+    public HoneyClientBuilder ioThreadCount(int ioThreadCount) {
         transportOptionsBuilder.setIoThreadCount(ioThreadCount);
         return this;
     }
 
-    public HoneyClientBuilder setMaximumHttpRequestShutdownWait(long maximumHttpRequestShutdownWait) {
+    public HoneyClientBuilder maximumHttpRequestShutdownWait(long maximumHttpRequestShutdownWait) {
         transportOptionsBuilder.setMaximumHttpRequestShutdownWait(maximumHttpRequestShutdownWait);
         return this;
     }
 
-    public HoneyClientBuilder setAdditionalUserAgent(String additionalUserAgent) {
+    public HoneyClientBuilder additionalUserAgent(String additionalUserAgent) {
         transportOptionsBuilder.setAdditionalUserAgent(additionalUserAgent);
         return this;
     }
 
-    public HoneyClientBuilder setProxyNoCredentials(String proxyHost) {
+    public HoneyClientBuilder proxyNoCredentials(String proxyHost) {
         transportOptionsBuilder.setProxy(new HttpHost(proxyHost));
         return this;
     }
 
-    public HoneyClientBuilder setSSLContext(SSLContext sslContext) {
+    public HoneyClientBuilder sslContext(SSLContext sslContext) {
         transportOptionsBuilder.setSSLContext(sslContext);
         return this;
     }
 
-    public HoneyClientBuilder setDataSet(String dataSet) {
+    public HoneyClientBuilder dataSet(String dataSet) {
         optionsBuilder.setDataset(dataSet);
         return this;
     }
 
-    public HoneyClientBuilder setApiHost(String apiHost) throws URISyntaxException {
+    public HoneyClientBuilder apiHost(String apiHost) throws URISyntaxException {
         optionsBuilder.setApiHost(new URI(apiHost));
         return this;
     }
 
-    public HoneyClientBuilder setWriteKey(String writeKey) {
+    public HoneyClientBuilder writeKey(String writeKey) {
         optionsBuilder.setWriteKey(writeKey);
         return this;
     }
 
-    public HoneyClientBuilder setDebugFlag(boolean flag){
+    public HoneyClientBuilder debug(boolean flag){
         this.debugEnabled = flag;
         return this;
     }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -34,8 +34,8 @@ public class HoneyClientBuilder {
     private final Map<String, Credentials> credentialMap = new HashMap<>();
     // HoneyClient TransportOptions END
 
-    TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
-    Options.Builder optionsBuilder = new Options.Builder();
+    protected TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
+    protected Options.Builder optionsBuilder = new Options.Builder();
 
     /**
      * Build new HoneyClient instance
@@ -129,10 +129,6 @@ public class HoneyClientBuilder {
         return this;
     }
 
-    public HoneyClientBuilder maximumPendingBatchRequests(int maximumPendingBatchRequests) {
-        transportOptionsBuilder.setMaximumPendingBatchRequests(maximumPendingBatchRequests);
-        return this;
-    }
 
     public HoneyClientBuilder maxPendingBatchRequests(int maxPendingBatchRequests) {
         transportOptionsBuilder.setMaximumPendingBatchRequests(maxPendingBatchRequests);

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -23,19 +23,13 @@ import java.util.List;
 import java.util.Map;
 
 public class HoneyClientBuilder {
-    private List<ResponseObserver> responseObservers = new ArrayList<>();
-    private boolean debugEnabled = false;
-
-    // HoneyClient Options START
     private final Map<String, Object> globalFields = new HashMap<>();
     private final Map<String, ValueSupplier<?>> globalDynamicFields = new HashMap<>();
-    // HoneyClient Options END
-
     private final Map<String, Credentials> credentialMap = new HashMap<>();
-    // HoneyClient TransportOptions END
-
     protected TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
     protected Options.Builder optionsBuilder = new Options.Builder();
+    private List<ResponseObserver> responseObservers = new ArrayList<>();
+    private boolean debugEnabled = false;
 
     /**
      * Build new HoneyClient instance
@@ -51,18 +45,18 @@ public class HoneyClientBuilder {
     }
 
     private void configureClient(HoneyClient client) {
-        if(!responseObservers.isEmpty()){
+        if (!responseObservers.isEmpty()) {
             for (ResponseObserver responseObserver : responseObservers) {
                 client.addResponseObserver(responseObserver);
             }
         }
-        if(debugEnabled){
+        if (debugEnabled) {
             client.addResponseObserver(new DefaultDebugResponseObserver());
         }
     }
 
     private void configureTransportOptionBuilder() {
-        if(!credentialMap.isEmpty()){
+        if (!credentialMap.isEmpty()) {
             transportOptionsBuilder.setCredentialsProvider(createCredentialsProvider());
         }
     }
@@ -80,10 +74,10 @@ public class HoneyClientBuilder {
     }
 
     private void configureOptionBuilder() {
-        if(!globalFields.isEmpty()){
+        if (!globalFields.isEmpty()) {
             optionsBuilder.setGlobalFields(globalFields);
         }
-        if(!globalDynamicFields.isEmpty()){
+        if (!globalDynamicFields.isEmpty()) {
             optionsBuilder.setGlobalDynamicFields(globalDynamicFields);
         }
     }
@@ -205,7 +199,7 @@ public class HoneyClientBuilder {
         return this;
     }
 
-    public HoneyClientBuilder debug(boolean flag){
+    public HoneyClientBuilder debug(boolean flag) {
         this.debugEnabled = flag;
         return this;
     }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -40,8 +40,7 @@ public class HoneyClientBuilder {
 
     /**
      * Build new HoneyClient instance as configured by calling the various builder methods previous to this call.
-     * <p/>
-     * <h3>Example</h3>
+     * <p><h3>Example</h3></p>
      * <pre>{@code
      * HoneyClient client = new HoneyClientBuilder()
      *                          .dataSet("dataset")
@@ -133,7 +132,7 @@ public class HoneyClientBuilder {
 
     /**
      * Use this method to configure the HTTP client to use a proxy that needs authentication.
-     * <p/>
+     * <p>
      * For configuring a proxy server without authentication see: {@link #addProxyNoCredential(String)}
      *
      * @param proxyHost hostname of the proxy, frequently FQDN of the server
@@ -204,7 +203,7 @@ public class HoneyClientBuilder {
      * <p>
      * Default: 100
      *
-     * @param batchTimeoutMillis milliseconds to send non-empty but not-full batch.
+     * @param batchTimeoutMillis max milliseconds to send a non-empty but not-full batch.
      */
     public HoneyClientBuilder batchTimeoutMillis(final long batchTimeoutMillis) {
         transportOptionsBuilder.setBatchTimeoutMillis(batchTimeoutMillis);
@@ -400,7 +399,7 @@ public class HoneyClientBuilder {
 
     /**
      * Use this method to configure the HTTP client to use a proxy without authentication.
-     * <p/>
+     * <p>
      * For configuring a proxy server with authentication see: {@link #addProxyCredential(String, String, String)}
      *
      * @param host hostname of the proxy, frequently FQDN of the server
@@ -437,6 +436,7 @@ public class HoneyClientBuilder {
      *
      * @param apiHost to set.
      * @see Options.Builder#setApiHost(java.net.URI)
+     * @throws URISyntaxException
      */
     public HoneyClientBuilder apiHost(final String apiHost) throws URISyntaxException {
         optionsBuilder.setApiHost(new URI(apiHost));

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -10,6 +10,7 @@ import io.honeycomb.libhoney.Options;
 import io.honeycomb.libhoney.ResponseObserver;
 import io.honeycomb.libhoney.TransportOptions;
 import io.honeycomb.libhoney.ValueSupplier;
+import io.honeycomb.libhoney.transport.Transport;
 import io.honeycomb.libhoney.transport.batch.impl.HoneycombBatchConsumer;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -36,6 +37,7 @@ public class HoneyClientBuilder {
     private final List<ResponseObserver> responseObservers = new ArrayList<>();
     protected TransportOptions.Builder transportOptionsBuilder = new TransportOptions.Builder();
     protected Options.Builder optionsBuilder = new Options.Builder();
+    private Transport transport = null;
     private boolean debugEnabled = false;
 
     /**
@@ -53,10 +55,17 @@ public class HoneyClientBuilder {
     public HoneyClient build() {
         configureOptionBuilder();
         configureTransportOptionBuilder();
-        final HoneyClient client = new HoneyClient(optionsBuilder.build(), transportOptionsBuilder.build());
+        final HoneyClient client = createClient();
         configureClient(client);
         return client;
 
+    }
+
+    private HoneyClient createClient() {
+        if(transport==null){
+            return new HoneyClient(optionsBuilder.build(), transportOptionsBuilder.build());
+        }
+        return new HoneyClient(optionsBuilder.build(), transport);
     }
 
     private void configureClient(final HoneyClient client) {
@@ -313,7 +322,7 @@ public class HoneyClientBuilder {
      * @return HoneyClientBuilder instance
      * @see RequestConfig#getConnectTimeout()
      */
-    public HoneyClientBuilder connectTimeout(final int connectTimeout) {
+    public HoneyClientBuilder connectionTimeout(final int connectTimeout) {
         transportOptionsBuilder.setConnectTimeout(connectTimeout);
         return this;
     }
@@ -494,6 +503,15 @@ public class HoneyClientBuilder {
 
     public HoneyClientBuilder addResponseObserver(final ResponseObserver responseObserver) {
         responseObservers.add(responseObserver);
+        return this;
+    }
+
+    /**
+     * Transport for sending events to HoneyComb. Used by the {@link io.honeycomb.libhoney.HoneyClient} internals.
+     * This can also be used to disable sending events to Honeycomb by passing in a mock Transport.
+     */
+    public HoneyClientBuilder transport(final Transport transport){
+        this.transport = transport;
         return this;
     }
 

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -40,7 +40,7 @@ public class HoneyClientBuilder {
 
     /**
      * Build new HoneyClient instance as configured by calling the various builder methods previous to this call.
-     * <p><h3>Example</h3></p>
+     * <h3>Example</h3>
      * <pre>{@code
      * HoneyClient client = new HoneyClientBuilder()
      *                          .dataSet("dataset")

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/README.md
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/README.md
@@ -44,7 +44,7 @@ public class Example{
         client = new HoneyClientBuilder()
                     .dataSet("test-dataset")
                     .writeKey("WRITE_KEY")
-                    .addProxyNoCredential("https://myproxy.example.com")
+                    .addProxy("https://myproxy.example.com")
                     .build();
     }
 }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/README.md
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/README.md
@@ -1,0 +1,74 @@
+# Building HoneyClient with HoneyClientBuilder
+HoneyClientBuilder is a simple way to create HoneyClient instances.
+
+## Initialization
+This an example of creating a HoneyClient instance. The typical application will only have one HoneyClient instance.
+
+```java
+package com.example.myapp;
+
+import io.honeycomb.libhoney.builders.HoneyClientBuilder;
+import io.honeycomb.libhoney.HoneyClient;
+
+public class MyApp{
+    /// ...
+    public static void main( final String[] args ) {
+        final HoneyClientBuilder builder = new HoneyClientBuilder();
+        // Configure builder
+        builder.dataSet("test-dataset").writeKey("WRITE_KEY");
+        // Build instance
+        final HoneyClient client = builder.build();
+
+        // ...
+
+        // Call close at program termination to ensure all pending
+        // spans are sent.
+        client.close();
+    }
+}
+```
+
+## Working with a proxy
+If the application server needs to use an HTTP proxy, configure it like this.
+
+```java
+package com.example.myapp;
+
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.builders.HoneyClientBuilder;
+
+public class Example{
+    HoneyClient client;
+
+    public Example(){
+        client = new HoneyClientBuilder()
+                    .dataSet("test-dataset")
+                    .writeKey("WRITE_KEY")
+                    .addProxyNoCredential("https://myproxy.example.com")
+                    .build();
+    }
+}
+```
+
+## Configuring Libhoney to disable sending events to Honeycomb
+Setting the `Transport` to a custom implementation (i.e. mock) can be used to disable sending data to Honeycomb.
+
+```java
+package com.example.myapp;
+
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.builders.HoneyClientBuilder;
+import com.example.MyApp.MockTransport;
+
+public class Example{
+    HoneyClient client;
+
+    public Example(){
+        client = new HoneyClientBuilder()
+                    .dataSet("test-dataset")
+                    .writeKey("WRITE_KEY")
+                    .transport(new MockTransport())
+                    .build();
+    }
+}
+```

--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/README.md
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/README.md
@@ -50,6 +50,28 @@ public class Example{
 }
 ```
 
+## Working with a proxy using BasicAuthentication
+If the application server needs to use an HTTP proxy, configure it like this.
+
+```java
+package com.example.myapp;
+
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.builders.HoneyClientBuilder;
+
+public class Example{
+    HoneyClient client;
+
+    public Example(){
+        client = new HoneyClientBuilder()
+                    .dataSet("test-dataset")
+                    .writeKey("WRITE_KEY")
+                    .addProxy("https://myproxy.example.com", "user", System.getenv("proxy_password"))
+                    .build();
+    }
+}
+```
+
 ## Configuring Libhoney to disable sending events to Honeycomb
 Setting the `Transport` to a custom implementation (i.e. mock) can be used to disable sending data to Honeycomb.
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/End2EndBuilderTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/End2EndBuilderTest.java
@@ -51,15 +51,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This ensures HoneyClientBuilder created clients match expected results as defined by {@link End2EndTest}.
  */
 public class End2EndBuilderTest {
-
+    private static final String LOCAL_TEST_URL = "http://localhost:8089";
+    private static final int LOCAL_TEST_PORT = 8089;
     @Rule
-    public WireMockRule wireMock = new WireMockRule(8089);
+    public WireMockRule wireMock = new WireMockRule(LOCAL_TEST_PORT);
 
     private HoneyClient honeyClient;
     private BlockingQueue<Response> notifyQueue;
 
     @Before
     public void setup() {
+        // 200 is HTTP response (transport level response)
+        // 202 is Honeycomb response for batch successfully enqueued for processing
         stubServer(200, "[" +
             "  {\"status\": 202}" +
             "]");
@@ -73,7 +76,7 @@ public class End2EndBuilderTest {
 
 
     private HoneyClientBuilder createBuilder() throws URISyntaxException {
-        return new HoneyClientBuilder().writeKey("testWriteKey").dataSet("testDataSet").apiHost("http://localhost:8089");
+        return new HoneyClientBuilder().writeKey("testWriteKey").dataSet("testDataSet").apiHost(LOCAL_TEST_URL);
     }
 
     private void createClientWithoutTimeout() throws URISyntaxException {

--- a/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
@@ -31,15 +31,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This class defines the test spec of the client. Any upate to this should be reflected in {@link End2EndBuilderTest}
  */
 public class End2EndTest {
+    private static final String LOCAL_TEST_URL = "http://localhost:8089";
+    private static final int LOCAL_TEST_PORT = 8089;
 
     @Rule
-    public WireMockRule wireMock = new WireMockRule(8089);
+    public WireMockRule wireMock = new WireMockRule(LOCAL_TEST_PORT);
 
     private HoneyClient honeyClient;
     private BlockingQueue<Response> notifyQueue;
 
     @Before
     public void setup() {
+        // 200 is HTTP response (transport level response)
+        // 202 is Honeycomb response for batch successfully enqueued for processing
         stubServer(200, "[" +
             "  {\"status\": 202}" +
             "]");
@@ -50,7 +54,7 @@ public class End2EndTest {
         honeyClient = new HoneyClient(LibHoney.options()
             .setWriteKey("testWriteKey")
             .setDataset("testDataSet")
-            .setApiHost(URI.create("http://localhost:8089"))
+            .setApiHost(URI.create(LOCAL_TEST_URL))
             .build());
         notifyQueue = createObserverQueue();
     }
@@ -59,7 +63,7 @@ public class End2EndTest {
         honeyClient = new HoneyClient(LibHoney.options()
             .setWriteKey("testWriteKey")
             .setDataset("testDataSet")
-            .setApiHost(URI.create("http://localhost:8089"))
+            .setApiHost(URI.create(LOCAL_TEST_URL))
             .build(),
             TransportOptions.builder().setBatchTimeoutMillis(Long.MAX_VALUE).build());
         notifyQueue = createObserverQueue();
@@ -147,7 +151,7 @@ public class End2EndTest {
                     eventData.addField("PostProcessData", new TestData().setInnerData("inner"));
                 }
             })
-            .setApiHost(URI.create("http://localhost:8089"))
+            .setApiHost(URI.create(LOCAL_TEST_URL))
             .build());
         final BlockingQueue<Response> notifyQueue = createObserverQueue();
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/End2EndTest.java
@@ -29,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This class defines the test spec of the client. Any upate to this should be reflected in {@link End2EndBuilderTest}
- *
  */
 public class End2EndTest {
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class HoneyClientBuilderTest {
 
@@ -59,6 +60,7 @@ public class HoneyClientBuilderTest {
         Assert.assertNotNull("Expected proxy credential to be found", credentials);
         Assert.assertEquals("Expected proxy user to match", "user", credentials.getUserPrincipal().getName());
         Assert.assertEquals("Expected password to match", "pass", credentials.getPassword());
+        //noinspection ResultOfMethodCallIgnored
         verify(transportBuilder, times(1)).getCredentialsProvider();
         completeNegativeVerification();
     }
@@ -74,6 +76,7 @@ public class HoneyClientBuilderTest {
         final HoneyClient client = builder.addGlobalDynamicFields("name", supplier1).build();
         verify(optionBuilder, times(1)).setGlobalDynamicFields(any(Map.class));
         final Map<String, ValueSupplier<?>> actualFields = optionBuilder.getGlobalDynamicFields();
+        //noinspection ResultOfMethodCallIgnored
         verify(optionBuilder, times(1)).getGlobalDynamicFields();
         Assert.assertEquals("Expected 1 global dynamic field", 1, actualFields.size());
         Assert.assertTrue("Expected value supplier key to exist", actualFields.containsKey("name"));
@@ -142,7 +145,7 @@ public class HoneyClientBuilderTest {
 
     @Test
     public void testProxyNoCredential() {
-        final HoneyClient client = builder.proxyNoCredentials("proxyHost").build();
+        final HoneyClient client = builder.addProxyNoCredential("proxyHost").build();
         verify(transportBuilder, times(1)).setProxy(any(HttpHost.class));
         completeNegativeVerification();
     }

--- a/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
@@ -5,6 +5,7 @@ import io.honeycomb.libhoney.Options;
 import io.honeycomb.libhoney.TransportOptions;
 import io.honeycomb.libhoney.ValueSupplier;
 import io.honeycomb.libhoney.responses.ResponseObservable;
+import io.honeycomb.libhoney.transport.Transport;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -17,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.net.ssl.SSLContext;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -30,7 +32,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("resource")
 @RunWith(MockitoJUnitRunner.class)
 public class HoneyClientBuilderTest {
 
@@ -214,8 +215,8 @@ public class HoneyClientBuilderTest {
     }
 
     @Test
-    public void testConnectTimeout() {
-        final HoneyClient client = builder.connectTimeout(123).build();
+    public void testConnectionTimeout() {
+        final HoneyClient client = builder.connectionTimeout(123).build();
         verify(transportBuilder, times(1)).setConnectTimeout(123);
         completeNegativeVerification();
     }
@@ -239,6 +240,17 @@ public class HoneyClientBuilderTest {
         final HoneyClient client = builder.batchSize(123).build();
         verify(transportBuilder, times(1)).setBatchSize(123);
         completeNegativeVerification();
+    }
+
+    @Test
+    public void testTransport() throws NoSuchFieldException, IllegalAccessException {
+        final Transport mockTransport = mock(Transport.class);
+        final HoneyClient client = builder.transport(mockTransport).build();
+        final Field field = HoneyClient.class.getDeclaredField("transport");
+        field.setAccessible(true);
+        final Object actualValue = field.get(client);
+        Assert.assertTrue("Expected reflected transport value to be instance of Transport", Transport.class.isAssignableFrom(actualValue.getClass()));
+        Assert.assertSame("Expected transport to be the same", mockTransport, (Transport) actualValue);
     }
 
     private void completeNegativeVerification() {

--- a/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
@@ -1,0 +1,231 @@
+package io.honeycomb.libhoney.builders;
+
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.Options;
+import io.honeycomb.libhoney.TransportOptions;
+import io.honeycomb.libhoney.ValueSupplier;
+import io.honeycomb.libhoney.responses.ResponseObservable;
+import org.apache.http.HttpHost;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.net.ssl.SSLContext;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HoneyClientBuilderTest {
+
+    @Mock
+    ResponseObservable mockObservable;
+    Options.Builder optionBuilder;
+    TransportOptions.Builder transportBuilder;
+
+    private HoneyClientBuilder builder;
+
+    @Before
+    public void setUp() {
+        builder = new HoneyClientBuilder();
+        transportBuilder = builder.transportOptionsBuilder = spy(builder.transportOptionsBuilder);
+        optionBuilder = builder.optionsBuilder = spy(builder.optionsBuilder);
+
+        when(optionBuilder.build()).thenCallRealMethod();
+        when(transportBuilder.build()).thenCallRealMethod();
+    }
+
+    @Test
+    public void testAddGlobalDynamicField() {
+        final ValueSupplier<Object> supplier1 = new ValueSupplier<Object>() {
+            @Override
+            public Object supply() {
+                return null;
+            }
+        };
+        final HoneyClient client = builder.addGlobalDynamicFields("name", supplier1).build();
+        verify(optionBuilder, times(1)).setGlobalDynamicFields(any(Map.class));
+        final Map<String, ValueSupplier<?>> actualFields = optionBuilder.getGlobalDynamicFields();
+        verify(optionBuilder, times(1)).getGlobalDynamicFields();
+        Assert.assertEquals("Expected 1 global dynamic field", 1, actualFields.size());
+        Assert.assertTrue("Expected value supplier key to exist", actualFields.containsKey("name"));
+        Assert.assertSame("Expected value supplier to match", supplier1, actualFields.get("name"));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testAddGlobalField() {
+        final HoneyClient client = builder.addGlobalField("name", "value").build();
+        final Map<String, Object> fields = client.createEvent().getFields();
+
+        Assert.assertEquals("Expected one field", 1, fields.size());
+        Assert.assertEquals("Expected map to match", Collections.singletonMap("name", "value"), fields);
+        verify(optionBuilder, times(1)).setGlobalFields(any(Map.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testMultipleGlobalFields() {
+        final HoneyClient client = builder
+            .addGlobalField("name", "value")
+            .addGlobalField("name2", "value2")
+            .build();
+        final Map<String, Object> fields = client.createEvent().getFields();
+        Assert.assertEquals("Expected two global fields", 2, fields.size());
+        Assert.assertTrue("Expected name as key", fields.containsKey("name"));
+        Assert.assertTrue("Expected name2 as key", fields.containsKey("name2"));
+        Assert.assertEquals("Expected value to match", "value", fields.get("name"));
+        Assert.assertEquals("Expected value to match", "value2", fields.get("name2"));
+        verify(optionBuilder, times(1)).setGlobalFields(any(Map.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testWriteKey() {
+        final HoneyClient client = builder.writeKey("testWriteKey").build();
+        Assert.assertEquals("Expected write key", "testWriteKey", client.createEvent().getWriteKey());
+        verify(optionBuilder, times(1)).setWriteKey("testWriteKey");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testApiHost() throws URISyntaxException {
+        final HoneyClient client = builder.apiHost("HOST:80").build();
+        Assert.assertEquals("Expected host to be present", "HOST:80", client.createEvent().getApiHost().toString());
+        verify(optionBuilder, times(1)).setApiHost(any(URI.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testdataSet() {
+        final HoneyClient client = builder.dataSet("set").build();
+        Assert.assertEquals("Expected dataset to be set", "set", client.createEvent().getDataset());
+        verify(optionBuilder, times(1)).setDataset("set");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testSSLContext() {
+        final SSLContext mockContext = mock(SSLContext.class);
+        final HoneyClient client = builder.sslContext(mockContext).build();
+        verify(transportBuilder, times(1)).setSSLContext(any(SSLContext.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testProxyNoCredential() {
+        final HoneyClient client = builder.proxyNoCredentials("proxyHost").build();
+        verify(transportBuilder, times(1)).setProxy(any(HttpHost.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testAdditionalUserAgent() {
+        final HoneyClient client = builder.additionalUserAgent("agent").build();
+        verify(transportBuilder, times(1)).setAdditionalUserAgent("agent");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testMaximumHttpRequestShutdownWait() {
+        final HoneyClient client = builder.maximumHttpRequestShutdownWait(345L).build();
+        verify(transportBuilder, times(1)).setMaximumHttpRequestShutdownWait(345L);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testIoThreadCount() {
+        final HoneyClient client = builder.ioThreadCount(1).build();
+        verify(transportBuilder, times(1)).setIoThreadCount(1);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testBufferSize() {
+        final HoneyClient client = builder.bufferSize(5_000).build();
+        verify(transportBuilder, times(1)).setBufferSize(5_000);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testSocketTimeout() {
+        final HoneyClient client = builder.socketTimeout(123).build();
+        verify(transportBuilder, times(1)).setSocketTimeout(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testConnectionRequestTimeout() {
+        final HoneyClient client = builder.connectionRequestTimeout(123).build();
+        verify(transportBuilder, times(1)).setConnectionRequestTimeout(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testMaximumPendingBatchRequests() {
+        final HoneyClient client = builder.maxPendingBatchRequests(123).build();
+        verify(transportBuilder, times(1)).setMaximumPendingBatchRequests(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testMaxConnections() {
+        final HoneyClient client = builder.maxConnections(123).build();
+        verify(transportBuilder, times(1)).setMaxConnections(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testMaxConnectionsPerApiHost() {
+        final HoneyClient client = builder.maxConnectionsPerApiHost(123).build();
+        verify(transportBuilder, times(1)).setMaxConnectionsPerApiHost(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testConnectTimeout() {
+        final HoneyClient client = builder.connectTimeout(123).build();
+        verify(transportBuilder, times(1)).setConnectTimeout(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testQueueCapacity() {
+        final HoneyClient client = builder.queueCapacity(123).build();
+        verify(transportBuilder, times(1)).setQueueCapacity(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testBatchTimeoutMillis() {
+        final HoneyClient client = builder.batchTimeoutMillis(123).build();
+        verify(transportBuilder, times(1)).setBatchTimeoutMillis(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testBatchSize() {
+        final HoneyClient client = builder.batchSize(123).build();
+        verify(transportBuilder, times(1)).setBatchSize(123);
+        completeNegativeVerification();
+    }
+
+    private void completeNegativeVerification() {
+        verify(optionBuilder, times(1)).build();
+        verify(transportBuilder, times(1)).build();
+        verifyNoMoreInteractions(optionBuilder);
+        verifyNoMoreInteractions(transportBuilder);
+    }
+}

--- a/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
@@ -54,7 +54,7 @@ public class HoneyClientBuilderTest {
 
     @Test
     public void testAddProxyCredentials() {
-        final HoneyClient client = builder.addProxyCredential("host:80", "user", "pass").build();
+        final HoneyClient client = builder.addProxy("host:80", "user", "pass").build();
         verify(transportBuilder, times(1)).setCredentialsProvider(any(CredentialsProvider.class));
         final CredentialsProvider actualValue = transportBuilder.getCredentialsProvider();
         final Credentials credentials = actualValue.getCredentials(AuthScope.ANY);
@@ -146,7 +146,7 @@ public class HoneyClientBuilderTest {
 
     @Test
     public void testProxyNoCredential() {
-        final HoneyClient client = builder.addProxyNoCredential("proxyHost").build();
+        final HoneyClient client = builder.addProxy("proxyHost").build();
         verify(transportBuilder, times(1)).setProxy(any(HttpHost.class));
         completeNegativeVerification();
     }

--- a/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
@@ -6,6 +6,9 @@ import io.honeycomb.libhoney.TransportOptions;
 import io.honeycomb.libhoney.ValueSupplier;
 import io.honeycomb.libhoney.responses.ResponseObservable;
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +48,19 @@ public class HoneyClientBuilderTest {
 
         when(optionBuilder.build()).thenCallRealMethod();
         when(transportBuilder.build()).thenCallRealMethod();
+    }
+
+    @Test
+    public void testAddProxyCredentials() {
+        final HoneyClient client = builder.addProxyCredential("host:80", "user", "pass").build();
+        verify(transportBuilder, times(1)).setCredentialsProvider(any(CredentialsProvider.class));
+        final CredentialsProvider actualValue = transportBuilder.getCredentialsProvider();
+        final Credentials credentials = actualValue.getCredentials(AuthScope.ANY);
+        Assert.assertNotNull("Expected proxy credential to be found", credentials);
+        Assert.assertEquals("Expected proxy user to match", "user", credentials.getUserPrincipal().getName());
+        Assert.assertEquals("Expected password to match", "pass", credentials.getPassword());
+        verify(transportBuilder, times(1)).getCredentialsProvider();
+        completeNegativeVerification();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.honeycomb.libhoney</groupId>
     <artifactId>libhoney-java-parent</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>libhoney-java (Parent)</name>
     <description>The Java client for sending events to Honeycomb (parent module)</description>


### PR DESCRIPTION
- Added HoneyClientBuilder to ease HoneyClient instance creation. See README in io.honeycomb.libhoney.builders package for usage. 
- Added DefaultDebugResponseObserver to provide debug ResponseObserver for users who directly use libhoney. 
  - HoneyClientBuilder will add DefaultDebugResponseObserver to HoneyClient ResponseObserver list when `debug(true)` is called on the builder. 
  - Provide explanatory messages for scenarios when Honeycomb API server cannot be reached.
- Bumped version to snapshot.