### PR TITLE
Add overload for setApitHost that takes URI as param

### DIFF
--- a/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/builders/HoneyClientBuilder.java
@@ -467,7 +467,22 @@ public class HoneyClientBuilder {
      * @see Options.Builder#setApiHost(java.net.URI)
      */
     public HoneyClientBuilder apiHost(final String apiHost) throws URISyntaxException {
-        optionsBuilder.setApiHost(new URI(apiHost));
+        apiHost(new URI(apiHost));
+        return this;
+    }
+
+    /**
+     * APIHost is the hostname for the Honeycomb API server to which to send this event.
+     * <p>
+     * Default: {@code https://api.honeycomb.io/}
+     *
+     * @param apiHost to set.
+     * @return HoneyClientBuilder instance
+     * @throws URISyntaxException if host is not valid URI syntax
+     * @see Options.Builder#setApiHost(java.net.URI)
+     */
+    public HoneyClientBuilder apiHost(final URI apiHost) throws URISyntaxException {
+        optionsBuilder.setApiHost(apiHost);
         return this;
     }
 

--- a/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/builders/HoneyClientBuilderTest.java
@@ -129,6 +129,14 @@ public class HoneyClientBuilderTest {
     }
 
     @Test
+    public void testApiHostWithURI() throws URISyntaxException {
+        final HoneyClient client = builder.apiHost(new URI("HOST:80")).build();
+        Assert.assertEquals("Expected host to be present", "HOST:80", client.createEvent().getApiHost().toString());
+        verify(optionBuilder, times(1)).setApiHost(any(URI.class));
+        completeNegativeVerification();
+    }
+
+    @Test
     public void testdataSet() {
         final HoneyClient client = builder.dataSet("set").build();
         Assert.assertEquals("Expected dataset to be set", "set", client.createEvent().getDataset());


### PR DESCRIPTION
Adds an overload to `HoneyClientBuilder.setApiHost` that takes a prebuilt _URI_. This is useful in the Beeline when a URI is created in the spring boot autoconf that is to be used with the builder and currently requires the URI to be cast to a string to then be parsed into a URI again.