### PR TITLE
Fix thin Jar building

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -29,25 +29,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${mavenJarPluginVersion}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>thin</classifier>
-                            <includes>
-                                <include>**/original-libhoney-java-*</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${shadeVersion}</version>
                 <configuration>
@@ -101,6 +82,29 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${mavenJarPluginVersion}</version>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/original-${project.build.finalName}.jar</file>
+                                    <type>jar</type>
+                                    <classifier>thin</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
- The previous method only appeared to work because of a dirty maven / git repo, and the newly released thin Jar is empty apart from Maven metadata.
- Because the shade and attach plugins both run in the package phase, their order is determined by order in the pom file.
- We must attach the Jar with the build-helper-maven-plugin, rather than build a new Jar.