### PR TITLE
Prepare 1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # libhoney Changelog
 
+## 1.3.1
+
+Fixes:
+
+- Run the plugin to attach the thin jar with classifier after others to ensure it uses a valid file (#37).
+
 ## 1.3.0
 
 Improvements:

--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>libhoney-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.honeycomb.libhoney</groupId>
     <artifactId>libhoney-java-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>pom</packaging>
     <name>libhoney-java (Parent)</name>
     <description>The Java client for sending events to Honeycomb (parent module)</description>


### PR DESCRIPTION
The 1.3.0 release included a change to build and publish a 'thin' version of the SDK where dependencies are not shaded (included) in the binary. This is useful for users who want to provide their own common dependencies.

However, the plugins run in order and the one that created the thin jar ran too early and didn't create a valid binary. The issue didn't show itself directly as a local maven cache prevented from being seen.