### PR TITLE
Prepare v1.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # libhoney Changelog
 
+## 1.3.2
+
+Maintenance:
+
+- Bump pmdCoreVersion from 6.36.0 to 6.37.0 (#61)
+- Bump maven-compiler-plugin from 3.7.0 to 3.8.1 (#55)
+- Bump maven-javadoc-plugin from 3.1.0 to 3.3.0 (#58)
+- Bump wiremock from 2.17.0 to 2.27.2 (#60)
+- Bump jackson-databind from 2.9.9.2 to 2.9.10.7 (#59)
+- Bump nexus-staging-maven-plugin from 1.6.7 to 1.6.8 (#57)
+- Bump jackson-core from 2.9.9 to 2.12.4 (#54)
+- Bump pmdCoreVersion from 6.3.0 to 6.36.0 (#50)
+- Bump maven-shade-plugin from 3.1.0 to 3.2.4 (#49)
+- Bump maven-surefire-plugin from 2.22.1 to 2.22.2 (#48)
+
 ## 1.3.1
 
 Fixes:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,8 @@
+# Release Process
+
+1. Add release entry to [changelog](./CHANGELOG.md)
+1. Update version in library pom.xml's [here](./pom.xml) and [here](./libhoney/pom.xml)
+1. Open a PR with the above, and merge that into main
+1. Create new tag on merged commit with the new version (e.g. `v1.3.2`)
+1. Push the tag upstream (this will kick off the release pipeline in CI)
+1. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps

--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java-parent</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </parent>
 
     <artifactId>libhoney-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.honeycomb.libhoney</groupId>
     <artifactId>libhoney-java-parent</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <packaging>pom</packaging>
     <name>libhoney-java (Parent)</name>
     <description>The Java client for sending events to Honeycomb (parent module)</description>


### PR DESCRIPTION
Updates library versions to v1.3.2 and adds change log entry.