### PR TITLE
Add specific dependency for apache.httpcomponents:httpcore-nio

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -213,6 +213,11 @@
             <version>${apacheClientVersion}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-nio</artifactId>
+            <version>${apacheHttpCoreVersion}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jacksonCoreVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 
         <!-- COMPILE dependency versions -->
         <apacheClientVersion>4.1.4</apacheClientVersion>
+        <apacheHttpCoreVersion>4.4.14</apacheHttpCoreVersion>
         <jacksonCoreVersion>2.13.0</jacksonCoreVersion>
         <jacksonDatabindVersion>2.13.0</jacksonDatabindVersion>
         <slf4jVersion>1.7.32</slf4jVersion>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
We use `org.apache.httpcomponents:httpasyncclient` which has a dependency on `org.apache.httpcomponents:httpcore-nio`. httpcore-nio has a memory leak bug that was fixed in 4.4.14.

- Fixes #96 

## Short description of the changes
- Adds specific dependency for httpcore-nio v4.4.14

cc @alamothe 