### PR TITLE
fix: add httpcore dependency

### DIFF
--- a/libhoney/pom.xml
+++ b/libhoney/pom.xml
@@ -214,6 +214,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${apacheHttpCoreVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
             <version>${apacheHttpCoreVersion}</version>
         </dependency>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #107 

## Short description of the changes

- Previously, the libhoney pom only included `httpcore-nio` as a dependency. The resulting shaded jar contained an older version of `httpcore` (4.4.10), and there is a change for ConnectionException available as of 4.4.11. Explicitly pulling in this `httpcore` dependency now uses 4.4.14 

```java
    /**
     * Creates a new ConnectionClosedException with the message "Connection is closed".
     *
     * @since 4.4.11
     */
    public ConnectionClosedException() {
        super("Connection is closed");
    }
```