### PR TITLE
Add support for environments and services

### DIFF
--- a/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
@@ -21,6 +21,7 @@ public class Options {
     public static final URI DEFAULT_API_HOST = URI.create("https://api.honeycomb.io/");
     public static final String DEFAULT_WRITE_KEY = null;
     public static final String DEFAULT_DATASET = null;
+    public static final String DEFAULT_NON_CLASSIC_DATASET = "unknown_service";
     public static final int DEFAULT_SAMPLE_RATE = 1;
     public static final Map<String, Object> DEFAULT_FIELDS = Collections.emptyMap();
     public static final Map<String, ValueSupplier<?>> DEFAULT_DYNAMIC_FIELDS = Collections.emptyMap();
@@ -53,6 +54,9 @@ public class Options {
         Assert.isTrue(this.sampleRate >= 1, "sampleRate must be 1 or greater");
     }
 
+    private boolean isClassic() {
+        return writeKey == null || writeKey == "" || writeKey.length() == 32;
+    }
 
     /**
      * @return api host.
@@ -75,7 +79,13 @@ public class Options {
      * @see Builder#setDataset(String)
      */
     public String getDataset() {
-        return dataset;
+        if (isClassic()) {
+            return dataset;
+        }
+        if (dataset == null || dataset.trim() == "") {
+            return DEFAULT_NON_CLASSIC_DATASET;
+        }
+        return dataset.trim();
     }
 
     /**
@@ -119,7 +129,7 @@ public class Options {
         return "Options{" +
             "apiHost=" + apiHost +
             ", writeKey=**********" +
-            ", dataset='" + dataset + '\'' +
+            ", dataset='" + getDataset() + '\'' +
             ", sampleRate=" + sampleRate +
             ", globalFields=" + globalFields +
             ", globalDynamicFields=" + globalDynamicFields +

--- a/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
@@ -21,7 +21,7 @@ public class Options {
     public static final URI DEFAULT_API_HOST = URI.create("https://api.honeycomb.io/");
     public static final String DEFAULT_WRITE_KEY = null;
     public static final String DEFAULT_DATASET = null;
-    public static final String DEFAULT_NON_CLASSIC_DATASET = "unknown_service";
+    public static final String DEFAULT_NON_CLASSIC_DATASET = "unknown_dataset";
     public static final int DEFAULT_SAMPLE_RATE = 1;
     public static final Map<String, Object> DEFAULT_FIELDS = Collections.emptyMap();
     public static final Map<String, ValueSupplier<?>> DEFAULT_DYNAMIC_FIELDS = Collections.emptyMap();

--- a/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
@@ -55,7 +55,7 @@ public class Options {
     }
 
     private boolean isClassic() {
-        return writeKey == null || writeKey == "" || writeKey.length() == 32;
+        return writeKey == null || writeKey.length() == 0 || writeKey.length() == 32;
     }
 
     /**
@@ -82,7 +82,7 @@ public class Options {
         if (isClassic()) {
             return dataset;
         }
-        if (dataset == null || dataset.trim() == "") {
+        if (dataset == null || dataset.trim().length() == 0) {
             return DEFAULT_NON_CLASSIC_DATASET;
         }
         return dataset.trim();

--- a/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
@@ -83,7 +83,11 @@ public class Options {
             return dataset;
         }
         if (dataset == null || dataset.trim().length() == 0) {
+            System.err.println("WARN: Dataset is empty or whitespace, using default: " + DEFAULT_NON_CLASSIC_DATASET);
             return DEFAULT_NON_CLASSIC_DATASET;
+        }
+        if (dataset != dataset.trim()) {
+            System.err.println("WARN: Dataset has unexpected whitespace, using trimmed version: " + DEFAULT_NON_CLASSIC_DATASET);
         }
         return dataset.trim();
     }

--- a/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
@@ -86,10 +86,11 @@ public class Options {
             System.err.println("WARN: Dataset is empty or whitespace, using default: " + DEFAULT_NON_CLASSIC_DATASET);
             return DEFAULT_NON_CLASSIC_DATASET;
         }
-        if (dataset != dataset.trim()) {
-            System.err.println("WARN: Dataset has unexpected whitespace, using trimmed version: " + DEFAULT_NON_CLASSIC_DATASET);
+        String trimmed = dataset.trim();
+        if (dataset != trimmed) {
+            System.err.println("WARN: Dataset has unexpected whitespace, using trimmed version: " + trimmed);
         }
-        return dataset.trim();
+        return trimmed;
     }
 
     /**

--- a/libhoney/src/test/java/io/honeycomb/libhoney/OptionsTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/OptionsTest.java
@@ -49,7 +49,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void Given_non_classic_writekey_and_null_dataset_getDataset_returns_unknown_service() {
+    public void Given_non_classic_writekey_and_null_dataset_getDataset_returns_unknown_dataset() {
         Options options = Options.builder()
             .setWriteKey("d68f9ed1e96432ac1a3380")
             .setDataset(null)
@@ -58,7 +58,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void Given_non_classic_writekey_and_empty_dataset_getDataset_returns_unknown_service() {
+    public void Given_non_classic_writekey_and_empty_dataset_getDataset_returns_unknown_dataset() {
         Options options = Options.builder()
             .setWriteKey("d68f9ed1e96432ac1a3380")
             .setDataset("")
@@ -67,7 +67,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void Given_non_classic_writekey_and_whitespace_dataset_getDataset_returns_unknown_service() {
+    public void Given_non_classic_writekey_and_whitespace_dataset_getDataset_returns_unknown_dataset() {
         Options options = Options.builder()
             .setWriteKey("d68f9ed1e96432ac1a3380")
             .setDataset("   ")

--- a/libhoney/src/test/java/io/honeycomb/libhoney/OptionsTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/OptionsTest.java
@@ -1,0 +1,86 @@
+package io.honeycomb.libhoney;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionsTest {
+
+    @Test
+    public void Given_null_writekey_and_no_dataset_getDataset_returns_empty() {
+        Options options = Options.builder()
+            .setWriteKey(null)
+            .build();
+        assertThat(options.getDataset()).isEqualTo(Options.DEFAULT_DATASET);
+    }
+
+    @Test
+    public void Given_empty_writekey_and_no_dataset_getDataset_returns_empty() {
+        Options options = Options.builder()
+            .setWriteKey("")
+            .build();
+        assertThat(options.getDataset()).isEqualTo(Options.DEFAULT_DATASET);
+    }
+
+    @Test
+    public void Given_classic_writekey_and_no_dataset_getDataset_returns_empty() {
+        Options options = Options.builder()
+            .setWriteKey("c1a551c000d68f9ed1e96432ac1a3380")
+            .build();
+        assertThat(options.getDataset()).isEqualTo(Options.DEFAULT_DATASET);
+    }
+
+    @Test
+    public void Given_classic_writekey_and_a_whitespace_dataset_getDataset_does_not_trim_whitespace() {
+        Options options = Options.builder()
+            .setWriteKey("c1a551c000d68f9ed1e96432ac1a3380")
+            .setDataset("   ")
+            .build();
+        assertThat(options.getDataset()).isEqualTo("   ");
+    }
+
+    @Test
+    public void Given_classic_writekey_and_a_dataset_getDataset_does_not_trim_whitespace() {
+        Options options = Options.builder()
+            .setWriteKey("c1a551c000d68f9ed1e96432ac1a3380")
+            .setDataset(" my-service ")
+            .build();
+        assertThat(options.getDataset()).isEqualTo(" my-service ");
+    }
+
+    @Test
+    public void Given_non_classic_writekey_and_null_dataset_getDataset_returns_unknown_service() {
+        Options options = Options.builder()
+            .setWriteKey("d68f9ed1e96432ac1a3380")
+            .setDataset(null)
+            .build();
+        assertThat(options.getDataset()).isEqualTo(Options.DEFAULT_NON_CLASSIC_DATASET);
+    }
+
+    @Test
+    public void Given_non_classic_writekey_and_empty_dataset_getDataset_returns_unknown_service() {
+        Options options = Options.builder()
+            .setWriteKey("d68f9ed1e96432ac1a3380")
+            .setDataset("")
+            .build();
+        assertThat(options.getDataset()).isEqualTo(Options.DEFAULT_NON_CLASSIC_DATASET);
+    }
+
+    @Test
+    public void Given_non_classic_writekey_and_whitespace_dataset_getDataset_returns_unknown_service() {
+        Options options = Options.builder()
+            .setWriteKey("d68f9ed1e96432ac1a3380")
+            .setDataset("   ")
+            .build();
+        assertThat(options.getDataset()).isEqualTo(Options.DEFAULT_NON_CLASSIC_DATASET);
+    }
+
+    @Test
+    public void Given_non_classic_writekey_and_a_dataset_getDataset_trims_whitespace() {
+        Options options = Options.builder()
+            .setWriteKey("d68f9ed1e96432ac1a3380")
+            .setDataset(" my-service ")
+            .build();
+        assertThat(options.getDataset()).isEqualTo("my-service");
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates the Options class to default to "unknown_service" or trim the dataset value if a non-classsic API (write) key is used. Default behaviour for classic API keys is unchanged.

- Closes #119 

## Short description of the changes
- Adds `isClassic` method to Options to check
- Updates `getDataset` to determine if in classic mode or not, if yes then dataset unmodified, if no then either return "unknown_dataset" or trimmed dataset string