### PR TITLE
Build example as part of CI test phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           steps:
             - run: mkdir -p ~/artifacts
             - run: mvn clean package -Dmaven.test.skip=true
-            - run: cp */target/*.jar ~/artifacts
+            - run: cp libhoney/target/*.jar ~/artifacts
             - persist_to_workspace:
                 root: ~/
                 paths:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,10 @@
 # Release Process
 
 1. Add release entry to [changelog](./CHANGELOG.md)
-1. Update version in library pom.xml's [here](./pom.xml) and [here](./libhoney/pom.xml)
+1. Update version in each pom.xml:
+ - [parent](./pom.xml)
+ - [library](./libhoney/pom.xml)
+ - [example](./examples/pom.xml)
 1. Open a PR with the above, and merge that into main
 1. Create new tag on merged commit with the new version (e.g. `v1.3.2`)
 1. Push the tag upstream (this will kick off the release pipeline in CI)

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.honeycomb.libhoney</groupId>
         <artifactId>libhoney-java-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.5.0</version>
     </parent>
 
     <artifactId>libhoney-java-examples</artifactId>
@@ -14,10 +14,10 @@
     <description>Example of using the Java client for sending events honeycomb</description>
 
     <dependencies>
-         <dependency>
-             <groupId>io.honeycomb.libhoney</groupId>
-             <artifactId>libhoney-java</artifactId>
-             <version>1.0.2</version>
-         </dependency>
-     </dependencies>
+        <dependency>
+            <groupId>io.honeycomb.libhoney</groupId>
+            <artifactId>libhoney-java</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
 
     <modules>
         <module>libhoney</module>
+        <module>examples</module>
      </modules>
 
     <profiles>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
We have a local example that demonstrates some expected usage patterns but is not tied directly to what it's the main projects. This change updates the CI build phase to also build the example to ensure we do not accidentally break APIs.

- Closes #131 

## Short description of the changes
- Add the example to the parent pom modules
- Update example dependency version to match current libhoney version
- Update RELEASING doc to ensure example dependency versions are updated during release prep
- Update CI package step to not store example jar / publish as part of github release