### PR TITLE
maint: add Java 18 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  maven: circleci/maven@1.0.3
+  maven: circleci/maven@1.3.0
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   package:
     executor: &default_executor
       name: maven/default
-      tag: "11.0"
+      tag: "17.0"
     steps:
       - checkout
       - maven/with_cache:
@@ -79,6 +79,7 @@ workflows:
                 - "11.0"
                 - "13.0"
                 - "17.0"
+                - "18.0"
   build:
     jobs:
       - test:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->


## Which problem is this PR solving?

- Java 18 was released in March 😄 

## Short description of the changes

- add to test matrix
- update default version to a more recent one (17)
- bump to latest maven orb while we're at it

