### PR TITLE
Fix javadoc generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - maven/with_cache:
           steps:
-            - run: mvn clean test
+            - run: mvn clean package
 
   package:
     executor: &default_executor

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${javadocPluginVersion}</version>
+                        <configuration>
+                            <source>8</source>
+                            <doclint>none</doclint>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -170,11 +174,14 @@
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${javadocPluginVersion}</version>
+                <configuration>
+                    <source>8</source>
+                    <doclint>none</doclint>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The javadoc step was failing because of some doc linting errors that was introduced after a recent update. This wasn't seen until a release was tried to be processed as javadocs are not created until the publish step.

This PR updates the java source of the javadoc step to use java 8 API and also ignore doc lint errors. I've also updated the test phase run on PRs to ensure we verify we can build the javadoc earlier.

## Short description of the changes
- Always build javadoc by using `package` instead of `test` in build step in CI
- Set java source to 8 and ignore doc lint errors when creating javadocs