### PR TITLE
maint: local reference for examples

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,9 +15,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.honeycomb.libhoney</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>libhoney-java</artifactId>
-            <version>1.5.3</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- examples module is using a hard version reference to libhoney, so you can't use the examples to test local changes to libhoney

## Short description of the changes

- use local module reference so that examples run with local changes to libhoney

