### PR TITLE
maint: ignore mockito 5 upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    ignore:
+      # Mockito 5.x.x requires Java 11 min version
+      - dependency-name: "org.mockito:mockito-*"
+        update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- new version requires Java 11 or higher

