### PR TITLE
feat: Add support for classic ingest keys

### DIFF
--- a/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
+++ b/libhoney/src/main/java/io/honeycomb/libhoney/Options.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static io.honeycomb.libhoney.utils.ObjectUtils.getOrDefault;
 
@@ -26,6 +27,8 @@ public class Options {
     public static final Map<String, Object> DEFAULT_FIELDS = Collections.emptyMap();
     public static final Map<String, ValueSupplier<?>> DEFAULT_DYNAMIC_FIELDS = Collections.emptyMap();
     public static final EventPostProcessor DEFAULT_EVENT_POST_PROCESSOR = null;
+    private static final Pattern CLASSIC_KEY_REGEX = Pattern.compile("^[a-f0-9]*$");
+    private static final Pattern INGEST_CLASSIC_KEY_REGEX = Pattern.compile("^hc[a-z]ic_[a-z0-9]*$");
 
     /// honeyclient properties
     private final URI apiHost;
@@ -54,8 +57,21 @@ public class Options {
         Assert.isTrue(this.sampleRate >= 1, "sampleRate must be 1 or greater");
     }
 
+    public static boolean isClassic(String key) {
+        if(key == null || key.length() == 0) {
+            return true;
+        }
+        else if(key.length() == 32) {
+            return CLASSIC_KEY_REGEX.matcher(key).matches();
+        }
+        else if(key.length() == 64) {
+            return INGEST_CLASSIC_KEY_REGEX.matcher(key).matches();
+        }
+        return false;
+    }
+
     private boolean isClassic() {
-        return writeKey == null || writeKey.length() == 0 || writeKey.length() == 32;
+        return isClassic(writeKey);
     }
 
     /**

--- a/libhoney/src/test/java/io/honeycomb/libhoney/IsClassicParameterizedTest.java
+++ b/libhoney/src/test/java/io/honeycomb/libhoney/IsClassicParameterizedTest.java
@@ -1,0 +1,69 @@
+package io.honeycomb.libhoney;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class IsClassicParameterizedTest {
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {
+                "full ingest key string, non classic",
+                "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc",
+                false
+            },
+            {
+                "ingest key id, non classic",
+                "hcxik_01hqk4k20cjeh63wca8vva5stw",
+                false
+            },
+            {
+                "full ingest key string,classic",
+                "hcaic_1234567890123456789012345678901234567890123456789012345678",
+                true
+            },
+            {
+                "ingest key id, classic",
+                "hcaic_12345678901234567890123456",
+                false
+            },
+            {
+                "v2 configuration key",
+                "kgvSpPwegJshQkuowXReLD",
+                false
+            },
+            {
+                "classic key",
+                "12345678901234567890123456789012",
+                true
+            },
+            {
+                "empty string",
+                "",
+                true
+            }
+        });
+    }
+
+    private final String input;
+    private final boolean expected;
+
+    public IsClassicParameterizedTest(String name, String input, boolean expected) {
+        this.input = input;
+        this.expected = expected;
+    }
+
+    @Test
+    public void test() {
+        assertThat(Options.isClassic(input)).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## Which problem is this PR solving?

We've released Ingest Keys, but need to update the key detection logic to allow Ingest Keys to be used to send data to Classic environments.

## Short description of the changes

- Updates the logic of `isClassic` to support ingest keys
- Moves `isClassic` logic to a public static method on the `Options` class so it can be re-used elsewhere
- Adds a parameterized test for `isClassic` to cover all cases

